### PR TITLE
feat: calendar api 연동

### DIFF
--- a/src/features/calendar/api/dailyResultsApi.js
+++ b/src/features/calendar/api/dailyResultsApi.js
@@ -1,0 +1,25 @@
+import api from "../../../shared/lib/api";
+
+/**
+ * GET /api/daily-results
+ * @param {string} startDate - YYYY-MM-DD
+ * @param {string} endDate - YYYY-MM-DD
+ * @returns {Promise<{success:boolean, message:string, data:Array<{date:string, bowlType:string}>, timestamp:string}>}
+ */
+export async function getDailyResults(startDate, endDate) {
+    const res = await api.get("/api/daily-results", {
+        params: { startDate, endDate },
+    });
+    return res.data;
+}
+
+
+export async function getDailyResultsMap(startDate, endDate) {
+    const body = await getDailyResults(startDate, endDate);
+    const list = Array.isArray(body?.data) ? body.data : [];
+
+    return list.reduce((acc, cur) => {
+        if (cur?.date) acc[cur.date] = cur.bowlType;
+        return acc;
+    }, {});
+}

--- a/src/features/calendar/components/CalendarIcon.js
+++ b/src/features/calendar/components/CalendarIcon.js
@@ -1,38 +1,23 @@
 import dayjs from 'dayjs';
 
 export const CALENDAR_ICONS = {
-    Empty: require('../assets/png/Empty.png'),
-    Little: require('../assets/png/Little.png'),
-    Many: require('../assets/png/Many.png'),
-    Full: require('../assets/png/Full.png'),
-    Burn: require('../assets/png/Burn.png'),
+    EMPTY: require('../assets/png/Empty.png'),
+    LITTLE: require('../assets/png/Little.png'),
+    MANY: require('../assets/png/Many.png'),
+    FULL: require('../assets/png/Full.png'),
+    BURNT: require('../assets/png/Burn.png'),
 };
 
-// 임시 데이터
-export const TEMP_TODO_MAP = {
-    '2025-12-10': { total: 4, completed: 2 },
-    '2025-12-11': { total: 3, completed: 0 },
-    '2025-12-12': { total: 0, completed: 0 },
-    '2025-12-13': { total: 3, completed: 1 },
-    '2025-12-14': { total: 4, completed: 2 },
-    '2025-12-15': { total: 2, completed: 2 },
-    '2025-12-16': { total: 3, completed: 0 },
-    '2025-12-17': { total: 4, completed: 2 },
-    '2025-12-19': { total: 3, completed: 0 },
-};
-
-export function getCalendarIconType(date, todo) {
+/**
+ * @param {string} date YYYY-MM-DD
+ * @param {string | undefined} bowlType  // 서버 값: EMPTY | LITTLE | MANY | FULL | BURNT
+ * @returns {keyof CALENDAR_ICONS | null}
+ */
+export function getCalendarIconType(date, bowlType) {
     const today = dayjs();
 
-    if (dayjs(date).isAfter(today, 'day')) return null; // 미래??
+    if (dayjs(date).isAfter(today, 'day')) return null;
+    if (!bowlType) return 'EMPTY';
 
-    if (!todo || todo.total === 0) return 'Empty'; // 빈그릇
-
-    const { total, completed } = todo;
-    const incomplete = total - completed;
-
-    if (completed === total) return 'Full';
-    if (completed === 0) return 'Burn';
-    if (completed >= incomplete) return 'Many';
-    return 'Little';
+    return bowlType;
 }

--- a/src/features/calendar/screens/CalendarScreen.jsx
+++ b/src/features/calendar/screens/CalendarScreen.jsx
@@ -11,10 +11,14 @@ import AppText from "../../../shared/components/AppText";
 import Dotted from "../assets/svg/Dotted.svg";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
+import { getDailyResults } from "../api/dailyResultsApi";
+
 export default function CalendarScreen() {
     const [mode, setMode] = useState("month"); // 'week' | 'month'
     const [currentDate, setCurrentDate] = useState(dayjs());
     const [selectedDate, setSelectedDate] = useState(dayjs());
+
+    const [bowlMap, setBowlMap] = useState([]);
 
     const handlePressToday = useCallback(() => {
         const today = dayjs();
@@ -41,6 +45,19 @@ export default function CalendarScreen() {
         });
     }, []);
 
+    useEffect(() => {
+        const startDate = currentDate.startOf("month").format("YYYY-MM-DD");
+        const endDate = currentDate.endOf("month").format("YYYY-MM-DD");
+
+        (async () => {
+            try {
+                const map = await getDailyResults(startDate, endDate);
+                setBowlMap(map);
+            } catch (e) {
+            }
+        })();
+    }, [currentDate]);
+
     return (
         <SafeAreaView className="flex-1 bg-wt" edges={["top", "bottom"]}>
             <CalendarHeader
@@ -61,6 +78,7 @@ export default function CalendarScreen() {
                                 selectedDate={selectedDate}
                                 onSelectDate={setSelectedDate}
                                 onChangeDate={setCurrentDate}
+                                bowlMap={bowlMap}
                             />
                         </View>
                         {/* 구분선 */}
@@ -79,6 +97,7 @@ export default function CalendarScreen() {
                     <MonthView
                         currentDate={currentDate}
                         onChangeDate={setCurrentDate}
+                        bowlMap={bowlMap}
                     />
                 )}
             </View>

--- a/src/features/calendar/screens/Month/MonthRow.jsx
+++ b/src/features/calendar/screens/Month/MonthRow.jsx
@@ -1,8 +1,8 @@
 import { View, Image, useWindowDimensions } from "react-native";
 import AppText from "../../../../shared/components/AppText";
-import { getCalendarIconType, CALENDAR_ICONS, TEMP_TODO_MAP } from "../../components/CalendarIcon";
+import { getCalendarIconType, CALENDAR_ICONS} from "../../components/CalendarIcon";
 
-export default function MonthRow({ days, isLast }) {
+export default function MonthRow({ days, isLast, bowlMap }) {
     const { width } = useWindowDimensions();
 
     return (
@@ -12,8 +12,8 @@ export default function MonthRow({ days, isLast }) {
                     if (!day) return <View key={idx} className="flex-1" />;
 
                     const dStr = day.format("YYYY-MM-DD");
-                    const todo = TEMP_TODO_MAP[dStr];
-                    const iconType = getCalendarIconType(day, todo);
+                    const bowlType = bowlMap?.[dStr];
+                    const iconType = getCalendarIconType(dStr, bowlType);
                     const Icon = iconType ? CALENDAR_ICONS[iconType] : null;
 
                     return (

--- a/src/features/calendar/screens/Week/WeekRow.jsx
+++ b/src/features/calendar/screens/Week/WeekRow.jsx
@@ -1,9 +1,9 @@
 import { View, TouchableOpacity, Image, useWindowDimensions } from "react-native";
 import dayjs from "dayjs";
 import AppText from "../../../../shared/components/AppText";
-import { getCalendarIconType, CALENDAR_ICONS, TEMP_TODO_MAP } from "../../components/CalendarIcon";
+import { getCalendarIconType, CALENDAR_ICONS} from "../../components/CalendarIcon";
 
-export default function WeekRow({ days, selectedDate, onSelectDate }) {
+export default function WeekRow({ days, selectedDate, onSelectDate, bowlMap }) {
     const { width } = useWindowDimensions();
     const todayStr = dayjs().format("YYYY-MM-DD");
 
@@ -15,8 +15,8 @@ export default function WeekRow({ days, selectedDate, onSelectDate }) {
                     const isToday = dStr === todayStr;
                     const isSelected = dStr === selectedDate.format("YYYY-MM-DD");
 
-                    const todo = TEMP_TODO_MAP[dStr];
-                    const iconType = getCalendarIconType(d, todo);
+                    const bowlType = bowlMap?.[dStr];
+                    const iconType = getCalendarIconType(dStr, bowlType);
                     const Icon = iconType ? CALENDAR_ICONS[iconType] : null;
 
                     return (


### PR DESCRIPTION
**📋 작업 개요**
- Calendar 화면 api 연동

**📝 작업 상세 설명**
- 서버 응답(date, bowlType)을 { [date]: bowlType } 형태로 가공
- 월간/주간 달력에서 공통으로 해당 데이터를 사용하도록 연동
- 기존 임시 데이터(TEMP_TODO_MAP) 제거
- bowlType 값 기준으로 캘린더 아이콘 표시 로직 수정