### PR TITLE
feat: category-continue

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,7 +15,10 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.hamsj2413.fryday"
+      "bundleIdentifier": "com.hamsj2413.fryday",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -38,10 +41,22 @@
         {
           "android": {
             "timePicker": {
-              "headerBackground": {"light": "#FF5B22", "dark": "#555555"},
-              "numbersSelectorColor": {"light": "#FF5B22", "dark": "#80CBC4"},
-              "background": {"light": "#FFFFFF", "dark": "#383838"},
-              "numbersBackgroundColor": {"light": "#EEEEEE", "dark": "#555555"}
+              "headerBackground": {
+                "light": "#FF5B22",
+                "dark": "#555555"
+              },
+              "numbersSelectorColor": {
+                "light": "#FF5B22",
+                "dark": "#80CBC4"
+              },
+              "background": {
+                "light": "#FFFFFF",
+                "dark": "#383838"
+              },
+              "numbersBackgroundColor": {
+                "light": "#EEEEEE",
+                "dark": "#555555"
+              }
             }
           }
         }

--- a/src/features/auth/api/socialLogin.js
+++ b/src/features/auth/api/socialLogin.js
@@ -48,8 +48,8 @@ export async function loginWithAccessToken(provider, accessToken, navigation) {
   //   index: 0,
   //   routes: [{name: nextRoute(data.onboardingStatus)}],
   // });
-  navigation.navigate("Category", {
-    screen: "CategList",
+  navigation.navigate("Main", {
+    screen: "Home",
   });
 }
 

--- a/src/features/auth/api/socialLogin.js
+++ b/src/features/auth/api/socialLogin.js
@@ -44,9 +44,12 @@ export async function loginWithAccessToken(provider, accessToken, navigation) {
     saveRefreshToken(String(data.refreshToken ?? "")),
   ]);
 
-  navigation.reset({
-    index: 0,
-    routes: [{name: nextRoute(data.onboardingStatus)}],
+  // navigation.reset({
+  //   index: 0,
+  //   routes: [{name: nextRoute(data.onboardingStatus)}],
+  // });
+  navigation.navigate("Category", {
+    screen: "CategList",
   });
 }
 
@@ -65,8 +68,11 @@ export async function loginWithCode(provider, code, navigation) {
     saveRefreshToken(String(data.refreshToken ?? "")),
   ]);
 
-  navigation.reset({
-    index: 0,
-    routes: [{name: nextRoute(data.onboardingStatus)}],
+  // navigation.reset({
+  //   index: 0,
+  //   routes: [{name: nextRoute(data.onboardingStatus)}],
+  // });
+  navigation.navigate("Category", {
+    screen: "CategList",
   });
 }

--- a/src/features/todo/components/TodoCard.jsx
+++ b/src/features/todo/components/TodoCard.jsx
@@ -18,6 +18,7 @@ import Animated, {
   runOnJS,
 } from "react-native-reanimated";
 import ChevronIcon from "../../../shared/components/ChevronIcon";
+import PlusIcon from "../assets/svg/Plus.svg";
 import colors from "../../../shared/styles/colors";
 
 /** ✅ 목업 투두 (규칙: 현재는 mock) */
@@ -246,9 +247,12 @@ export default function TodoCard({
             onPress={() => handlePressAddTodo(category.categoryId)}
             style={styles.addTodoButton}
           >
-            <AppText variant="M600" style={{color}}>
-              새 투두 튀기기 +
-            </AppText>
+            <View style={styles.addTodoContent}>
+              <AppText variant="M600" style={{color}}>
+                새 투두 튀기기
+              </AppText>
+              <PlusIcon width={14} height={14} color={color} />
+            </View>
           </TouchableOpacity>
         </View>
 
@@ -343,6 +347,11 @@ const styles = StyleSheet.create({
   addTodoButton: {
     paddingHorizontal: 6,
     paddingVertical: 8,
+  },
+  addTodoContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4, // 텍스트와   아이콘 간격
   },
 
   listArea: {

--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -28,6 +28,7 @@ import AlarmTimeSettingSection from "./AlarmTimeSettingsSection";
 import ChevronIcon from "../../../../shared/components/ChevronIcon";
 import YearMonthWheelModal from "../RepeatSettingsSection/wheel/YearMonthWheelModal";
 import {toast} from "../../../../shared/components/toast/CenterToast";
+import ClearIcon from "../../../../shared/assets/svg/Clear.svg";
 /**
  * ✅ BottomSheetTextInput만 분리 (IME-safe 로직 포함)
  * - 기존 로직 유지하면서 multiline 등 확장 props 추가
@@ -568,7 +569,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
                     style={styles.clearButton}
                     hitSlop={8}
                   >
-                    <Text style={styles.clearIcon}>×</Text>
+                    <ClearIcon width={16} height={16} color={colors.gr300} />
                   </TouchableOpacity>
                 )}
               </View>
@@ -636,7 +637,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
                     style={styles.clearButton}
                     hitSlop={8}
                   >
-                    <Text style={styles.clearIcon}>×</Text>
+                    <ClearIcon width={16} height={16} color={colors.gr300} />
                   </TouchableOpacity>
                 )}
               </View>
@@ -1002,11 +1003,11 @@ const styles = StyleSheet.create({
     width: 24,
     // borderWidth: 1,
   },
-  clearIcon: {
-    fontSize: 16,
-    lineHeight: 16,
-    color: "#B0B0B0",
-  },
+  // clearIcon: {
+  //   fontSize: 16,
+  //   lineHeight: 16,
+  //   color: "#B0B0B0",
+  // },
 
   // ===== edit tools row =====
   toolsRow: {

--- a/src/features/todo/screens/Category/CategEditScreen.jsx
+++ b/src/features/todo/screens/Category/CategEditScreen.jsx
@@ -54,6 +54,7 @@ const COLOR_CODE_MAP = {
 export default function CategEditScreen({navigation, route}) {
   const mode = route?.params?.mode ?? "create"; // "create" | "edit"
   const editingCategory = route?.params?.category ?? null;
+  const categoryCount = route?.params?.categoryCount ?? 0;
 
   const isEdit = mode === "edit";
 
@@ -169,6 +170,25 @@ export default function CategEditScreen({navigation, route}) {
         variant: "outline",
         onPress: () => {
           if (isDeleting) return;
+
+          // ✅ 카테고리는 최소 3개 유지
+          if (categoryCount <= 3) {
+            console.log("categorycount: ", categoryCount);
+            setTimeout(() => {
+              openModal({
+                title: "알림",
+                description: "카테고리는 최소 3개를 유지해야 해요!",
+                closeOnBackdrop: true,
+                showClose: true,
+                primary: {
+                  label: "확인했어요",
+                  variant: "primary",
+                  onPress: () => {},
+                },
+              });
+            }, 0);
+            return;
+          }
 
           deleteCategory({
             categoryId: editingCategory?.id, // ✅ path variable

--- a/src/features/todo/screens/Category/CategEditScreen.jsx
+++ b/src/features/todo/screens/Category/CategEditScreen.jsx
@@ -17,6 +17,7 @@ import ClearIcon from "../../../../shared/assets/svg/Clear.svg"; // ✅ 경로�
 import colors from "../../../../shared/styles/colors";
 
 import {useModalStore} from "../../../../shared/stores/modal/modalStore";
+import {useCreateCategoryMutation} from "../../queries/category/useCreateCategoryMutation";
 
 const MAX_NAME_LEN = 8;
 
@@ -31,6 +32,19 @@ const COLOR_OPTIONS = [
   colors.mb, // mint
   colors.pk, // light pink
 ];
+
+// ✅ hex → colorCode 매핑 (명세서용)
+const COLOR_CODE_MAP = {
+  [colors.or]: "OR",
+  [colors.br]: "BR",
+  [colors.lg]: "LG",
+  [colors.vl]: "VL",
+  [colors.dp]: "DP",
+  [colors.cb]: "CB",
+  [colors.mb2]: "MB2",
+  [colors.mb]: "MB",
+  [colors.pk]: "PK",
+};
 
 export default function CategEditScreen({navigation, route}) {
   const mode = route?.params?.mode ?? "create"; // "create" | "edit"
@@ -49,6 +63,20 @@ export default function CategEditScreen({navigation, route}) {
   const [isColorOpen, setIsColorOpen] = useState(false);
 
   const openModal = useModalStore((s) => s.open);
+
+  const {mutate: createCategory, isPending: isCreating} =
+    useCreateCategoryMutation({
+      onSuccess: () => {
+        // ✅ 생성 성공 → 목록 화면으로 이동
+        navigation?.navigate?.("CategList");
+      },
+      onError: (err) => {
+        console.log("[createCategory] error:", err);
+        console.log("[createCategory] message:", err?.message);
+        console.log("[createCategory] status:", err?.response?.status);
+        console.log("[createCategory] data:", err?.response?.data);
+      },
+    });
 
   const helperText = useMemo(
     () => `카테고리 이름은 ${MAX_NAME_LEN}자까지 입력할 수 있어요`,
@@ -74,11 +102,14 @@ export default function CategEditScreen({navigation, route}) {
   };
 
   const onPressCreate = () => {
-    if (!isSubmitEnabled) return;
+    if (!isSubmitEnabled || isCreating) return;
 
-    // TODO: create API 연결
-    // createCategory({ name: name.trim(), color: selectedColor })
-    navigation?.goBack?.();
+    const colorCode = COLOR_CODE_MAP[selectedColor];
+
+    createCategory({
+      name: name.trim(),
+      color: colorCode, // ✅ "BR", "OR", "LG" 형태로 전송
+    });
   };
 
   const onPressDelete = () => {
@@ -267,21 +298,25 @@ export default function CategEditScreen({navigation, route}) {
             <TouchableOpacity
               activeOpacity={0.8}
               onPress={onPressCreate}
-              disabled={!isSubmitEnabled}
+              disabled={!isSubmitEnabled || isCreating}
               style={[
                 styles.submitBtn,
-                !isSubmitEnabled && styles.submitBtnDisabled,
+                (!isSubmitEnabled || isCreating) && styles.submitBtnDisabled,
               ]}
             >
-              <AppText
-                variant="L600"
-                style={[
-                  styles.submitText,
-                  !isSubmitEnabled && styles.submitTextDisabled,
-                ]}
-              >
-                추가하기
-              </AppText>
+              {isCreating ? (
+                <ActivityIndicator />
+              ) : (
+                <AppText
+                  variant="L600"
+                  style={[
+                    styles.submitText,
+                    !isSubmitEnabled && styles.submitTextDisabled,
+                  ]}
+                >
+                  추가하기
+                </AppText>
+              )}
             </TouchableOpacity>
           )}
         </View>

--- a/src/features/todo/screens/Category/CategEditScreen.jsx
+++ b/src/features/todo/screens/Category/CategEditScreen.jsx
@@ -79,7 +79,8 @@ export default function CategEditScreen({navigation, route}) {
         // navigation?.navigate?.("CategList");
         // await queryClient.invalidateQueries({queryKey: categoryKeys.list()});
         await queryClient.refetchQueries({queryKey: categoryKeys.list()});
-        navigation?.navigate?.("CategList");
+        // navigation?.navigate?.("CategList");
+        navigation.goBack();
       },
       onError: (err) => {
         console.log("[createCategory] error:", err);
@@ -94,7 +95,8 @@ export default function CategEditScreen({navigation, route}) {
       onSuccess: async () => {
         // ✅ 수정 성공 → 목록으로 복귀(또는 navigate("CategList")도 가능)
         await queryClient.refetchQueries({queryKey: categoryKeys.list()});
-        navigation?.navigate?.("CategList");
+        // navigation?.navigate?.("CategList");
+        navigation.goBack();
       },
       onError: (err) => {
         console.log("[updateCategory] error:", err);
@@ -109,7 +111,8 @@ export default function CategEditScreen({navigation, route}) {
       onSuccess: async () => {
         // ✅ 삭제 성공 → 목록으로 이동(혹은 goBack)
         await queryClient.refetchQueries({queryKey: categoryKeys.list()});
-        navigation?.navigate?.("CategList");
+        // navigation?.navigate?.("CategList");
+        navigation.goBack();
       },
       onError: (err) => {
         console.log("[deleteCategory] error:", err);

--- a/src/features/todo/screens/Category/CategListScreen.jsx
+++ b/src/features/todo/screens/Category/CategListScreen.jsx
@@ -1,5 +1,5 @@
 // src/features/todo/screens/Category/CategListScreen.jsx
-import React, {useCallback, useMemo, useState} from "react";
+import React, {useCallback, useEffect, useMemo, useState} from "react";
 import {View, StyleSheet, TouchableOpacity} from "react-native";
 import {SafeAreaView} from "react-native-safe-area-context";
 import DraggableFlatList from "react-native-draggable-flatlist";
@@ -9,6 +9,7 @@ import CategoryItem from "../../components/Category/CategoryItem";
 import colors from "../../../../shared/styles/colors";
 import CategoryHeader from "../../components/Category/CategoryHeader";
 import {useCategoriesQuery} from "../../queries/category/useCategoriesQuery";
+import {toast} from "../../../../shared/components/toast/CenterToast";
 
 // const MOCK_CATEGORIES = [
 //   {id: "1", label: "카테고리 이름 1", color: colors.br},
@@ -26,6 +27,10 @@ export default function CategListScreen({navigation}) {
     isError,
     error,
   } = useCategoriesQuery();
+
+  useEffect(() => {
+    console.log("data: ", serverCategories);
+  }, [serverCategories]);
 
   if (isError) {
     // TanStack Query error는 보통 axios error일 가능성이 높음
@@ -54,7 +59,16 @@ export default function CategListScreen({navigation}) {
       <CategoryHeader
         variant="list"
         onPressBack={() => navigation.goBack()}
-        onPressPlus={() => navigation.navigate("CategEdit", {mode: "create"})}
+        onPressPlus={() => {
+          if (categories.length >= 6) {
+            toast.show("카테고리 개수는 최대 6개까지 생성할 수 있어요", {
+              position: "center",
+            });
+            return;
+          }
+
+          navigation.navigate("CategEdit", {mode: "create"});
+        }}
       />
 
       {isLoading ? (

--- a/src/features/todo/screens/Category/CategListScreen.jsx
+++ b/src/features/todo/screens/Category/CategListScreen.jsx
@@ -127,6 +127,7 @@ export default function CategListScreen({navigation}) {
                   navigation.navigate("CategEdit", {
                     mode: "edit",
                     category: item, // ✅ { id, label, color } 형태로 전달 (edit 초기값에 맞춤)
+                    categoryCount: categories.length, // ✅ 현재 전체 카테고리 개수 전달
                   })
                 }
               >

--- a/src/shared/lib/queryClient.js
+++ b/src/shared/lib/queryClient.js
@@ -1,10 +1,10 @@
 // src/shared/lib/queryClient.js
-import { QueryClient } from '@tanstack/react-query';
+import {QueryClient} from "@tanstack/react-query";
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 60 * 1000,   // 1분 동안 fresh
+      staleTime: 60 * 1000, // 1분 동안 fresh
       gcTime: 10 * 60 * 1000, // 10분 후 캐시 정리
       retry: 1,
       refetchOnReconnect: true,

--- a/src/shared/styles/colors.js
+++ b/src/shared/styles/colors.js
@@ -11,14 +11,14 @@ module.exports = {
   bl75: "rgba(51, 121, 182, 0.75)",
 
   // Secondary / Category
-  br: "#85302A",
+  br: "#693838",
   lg: "#82B236",
-  cb: "#367BAE",
-  dp: "#D05D90",
-  mb: "#3CB492",
+  cb: "#3E78AE",
+  dp: "#D0509D",
+  mt: "#3CB492",
   vl: "#9351A1",
   pk: "#F06B9C",
-  mb2: "#AA7459",
+  mb: "#AA7459",
   yl: "#FFA100",
 
   // Gray Scale

--- a/src/shared/styles/colors.js
+++ b/src/shared/styles/colors.js
@@ -19,7 +19,7 @@ module.exports = {
   vl: "#9351A1",
   pk: "#F06B9C",
   mb: "#AA7459",
-  yl: "#FFA100",
+  // yl: "#FFA100",
 
   // Gray Scale
   bk: "#282424",


### PR DESCRIPTION
📋 작업 개요
- 카테고리 리스트, 생성/편집 화면 구현
- 카테고리 추가/수정/삭제 로직 추가
- 카테고리 관련 API 연동

📝 작업 상세 설명
- 카테고리 리스트 조회 및 순서 변경
- 카테고리 추가 / 수정 화면 분기 처리 및 UI 상태 정리
- 카테고리 삭제 시 최소 개수(3개) 제한 로직 추가
- 삭제 불가 조건일 경우 안내 모달 노출
- fryday에서 사용하는 공통 모달 UI 구현
- API 실패 시 불러오기/저장하기 기반 공통 토스트 에러 메시지 처리
- 카테고리 관련 Query / Mutation 구조 정리