### PR TITLE
feat: 연월이동 모달 연동 및 알림 설정 연동

### DIFF
--- a/src/features/calendar/components/CalendarHeader.jsx
+++ b/src/features/calendar/components/CalendarHeader.jsx
@@ -11,17 +11,20 @@ export default function CalendarHeader({
   mode,
   onPressButton,
   onPressToday,
-  navigation,
+  navigation, onPressYearMonth,
 }) {
   return (
     <View className="w-full px-5 py-4 flex-row justify-between items-center">
       <View>
-        <AppText variant="M500" className="text-gr500">
-          {date.year()}년
-        </AppText>
-        <AppText variant="H3" className="mt-1 text-bk">
-          {date.month() + 1}월
-        </AppText>
+          <TouchableOpacity onPress={onPressYearMonth}>
+              <AppText variant="M500" className="text-gr500">
+                  {date.year()}년
+              </AppText>
+              <AppText variant="H3" className="mt-1 text-bk">
+                  {date.month() + 1}월
+              </AppText>
+          </TouchableOpacity>
+
       </View>
 
       <View className="flex-row items-center gap-3">

--- a/src/features/calendar/screens/CalendarScreen.jsx
+++ b/src/features/calendar/screens/CalendarScreen.jsx
@@ -88,6 +88,24 @@ export default function CalendarScreen({navigation}) {
         }, [mode])
     );
 
+    const handleSelectMonthDate = useCallback(
+        (d) => {
+            setSelectedDate(d);
+            const dateStr = d.format("YYYY-MM-DD");
+
+            requestAnimationFrame(() => {
+                navigation.navigate("Main", {
+                    screen: "Todo",
+                    params: {
+                        screen: "Home",
+                        params: { initialDate: dateStr },
+                    },
+                });
+            });
+        },
+        [navigation]
+    );
+
 
     return (
       <SafeAreaView className="flex-1 bg-wt" edges={["top"]}>
@@ -131,7 +149,7 @@ export default function CalendarScreen({navigation}) {
                   onChangeDate={setCurrentDate}
                   bowlMap={bowlMap}
                   selectedDate={selectedDate}
-                  onSelectDate={setSelectedDate}
+                  onSelectDate={handleSelectMonthDate}
               />
           )}
         </View>

--- a/src/features/calendar/screens/CalendarScreen.jsx
+++ b/src/features/calendar/screens/CalendarScreen.jsx
@@ -13,6 +13,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import TodoBoardSection from "../../todo/components/TodoBoardSection";
 import {getDailyResultsMap} from "../api/dailyResultsApi";
+import YearMonthWheelModal from "../../todo/components/RepeatSettingsSection/wheel/YearMonthWheelModal";
 
 export default function CalendarScreen({navigation}) {
   const [mode, setMode] = useState("month"); // 'week' | 'month'
@@ -22,7 +23,24 @@ export default function CalendarScreen({navigation}) {
   const selectedDateStr = selectedDate.format("YYYY-MM-DD");
   const isViewingToday = selectedDate.isSame(dayjs(), "day");
 
-  const [bowlMap, setBowlMap] = useState({});
+    const [isYMModalOpen, setIsYMModalOpen] = useState(false);
+
+    const openYMModal = useCallback(() => setIsYMModalOpen(true), []);
+    const closeYMModal = useCallback(() => setIsYMModalOpen(false), []);
+
+    const handleConfirmYM = useCallback((year, month) => {
+        // month: 1~12
+        const next = dayjs()
+            .year(year)
+            .month(month - 1)
+            .startOf("month");
+
+        setCurrentDate(next);
+        setIsYMModalOpen(false);
+    }, []);
+
+
+    const [bowlMap, setBowlMap] = useState({});
 
   const handlePressToday = useCallback(() => {
     const today = dayjs();
@@ -109,15 +127,16 @@ export default function CalendarScreen({navigation}) {
 
     return (
       <SafeAreaView className="flex-1 bg-wt" edges={["top"]}>
-        <CalendarHeader
-            date={currentDate}
-            mode={mode}
-            onPressButton={toggleMode}
-            onPressToday={handlePressToday}
-            navigation={navigation}
-        />
+          <CalendarHeader
+              date={currentDate}
+              mode={mode}
+              onPressButton={toggleMode}
+              onPressToday={handlePressToday}
+              navigation={navigation}
+              onPressYearMonth={openYMModal}
+          />
 
-        <WeekdayHeader />
+          <WeekdayHeader />
 
         <View className="flex-1">
           {mode === "week" ? (
@@ -153,6 +172,14 @@ export default function CalendarScreen({navigation}) {
               />
           )}
         </View>
+          <YearMonthWheelModal
+              visible={isYMModalOpen}
+              initialYear={currentDate.year()}
+              initialMonth={currentDate.month() + 1}
+              onCancel={closeYMModal}
+              onConfirm={handleConfirmYM}
+          />
+
       </SafeAreaView>
   );
 }

--- a/src/features/mypage/components/ToggleMenu.jsx
+++ b/src/features/mypage/components/ToggleMenu.jsx
@@ -1,34 +1,40 @@
-import React, {useState} from "react";
 import {View, Pressable} from "react-native";
 import AppText from "../../../shared/components/AppText";
 
-export default function ToggleMenu({title, content}) {
-    const [on, setOn] = useState(false);
-
+export default function ToggleMenu({
+                                       title,
+                                       content,
+                                       value,
+                                       onToggle,
+                                       disabled = false,
+                                   }) {
     return (
         <View className="py-3">
             <View className="flex-row justify-between items-center gap-2">
-            <View>
-                <AppText variant="L500" className="text-bk">
-                    {title}
-                </AppText>
-                <AppText variant="S500" className="text-gr500 py-1">
-                    {content}
-                </AppText>
-            </View>
+                <View>
+                    <AppText variant="L500" className="text-bk">
+                        {title}
+                    </AppText>
+                    <AppText variant="S500" className="text-gr500 py-1">
+                        {content}
+                    </AppText>
+                </View>
 
-            <Pressable
-                onPress={() => setOn(!on)}
-                className={`w-16 h-8 rounded-full px-1 justify-center ${
-                    on ? "bg-or" : "bg-gr300"
-                }`}
-            >
-                <View
-                    className={`w-5 h-5 rounded-full bg-white ${
-                        on ? "self-end" : "self-start"
-                    }`}
-                />
-            </Pressable>
+                <Pressable
+                    onPress={() => {
+                        if (disabled) return;
+                        onToggle?.(!value);
+                    }}
+                    className={`w-16 h-8 rounded-full px-1 justify-center ${
+                        value ? "bg-or" : "bg-gr300"
+                    } ${disabled ? "opacity-40" : ""}`}
+                >
+                    <View
+                        className={`w-5 h-5 rounded-full bg-white ${
+                            value ? "self-end" : "self-start"
+                        }`}
+                    />
+                </Pressable>
             </View>
         </View>
     );

--- a/src/features/mypage/screens/System/SystemAlarm.jsx
+++ b/src/features/mypage/screens/System/SystemAlarm.jsx
@@ -1,26 +1,75 @@
 import {SafeAreaView} from "react-native-safe-area-context";
 import MyPageHeader from "../../components/MypageHeader";
-import {View} from "react-native";
+import {View, Platform, Linking} from "react-native";
 import ToggleMenu from "../../components/ToggleMenu";
+import * as Notifications from "expo-notifications";
+import {useEffect, useState, useCallback} from "react";
 
-export default function SystemAlarm () {
-    return(
+export default function SystemAlarm() {
+    const [isPushEnabled, setIsPushEnabled] = useState(false);
+    const [isFryAlarmEnabled, setIsFryAlarmEnabled] = useState(false);
+
+    const syncWithSystemPermission = useCallback(async () => {
+        const {status} = await Notifications.getPermissionsAsync();
+        const allowed = status === "granted";
+        setIsPushEnabled(allowed);
+        setIsFryAlarmEnabled(allowed ? true : false); // 푸시 ON이면 튀김 기본 true
+        return allowed;
+    }, []);
+
+    useEffect(() => {
+        syncWithSystemPermission();
+    }, [syncWithSystemPermission]);
+
+    const openSystemSettings = useCallback(async () => {
+        if (Platform.OS === "ios") {
+            await Linking.openURL("app-settings:");
+            return;
+        }
+        await Linking.openSettings();
+    }, []);
+
+    const handleTogglePush = useCallback(
+        async (next) => {
+            if (!next) {
+                setIsPushEnabled(false);
+                setIsFryAlarmEnabled(false);
+                return;
+            }
+            const allowed = await syncWithSystemPermission();
+            if (allowed) return;
+
+            await openSystemSettings();
+        },
+        [openSystemSettings, syncWithSystemPermission]
+    );
+
+    return (
         <SafeAreaView className="flex-1">
             <MyPageHeader showBackButton title="알림 설정" />
             <View className="px-5 gap-6">
                 <ToggleMenu
                     title="푸시 알림"
                     content="프라이데이에서 보내는 푸시 알람을 받을 수 있어요"
+                    value={isPushEnabled}
+                    onToggle={handleTogglePush}
+                    allowPressWhenDisabled={true}
                 />
+
                 <ToggleMenu
                     title="튀김 알림"
                     content="내가 설정한 튀김 알림을 받을 수 있어요"
+                    value={isFryAlarmEnabled}
+                    onToggle={(v) => setIsFryAlarmEnabled(v)}
+                    disabled={!isPushEnabled}
                 />
+
                 <ToggleMenu
-                    title="푸시 알림"
+                    title="마케팅 정보 알림"
                     content="프라이데이의 새로운 소식 알람을 받을 수 있어요"
+                    disabled={!isPushEnabled}
                 />
             </View>
         </SafeAreaView>
-    )
-};
+    );
+}

--- a/src/features/report/components/ReportHeader.jsx
+++ b/src/features/report/components/ReportHeader.jsx
@@ -4,7 +4,7 @@ import AppText from '../../../shared/components/AppText';
 import ArrowLeft from '../assets/svg/ArrowLeft.svg';
 import ArrowRight from '../assets/svg/ArrowRight.svg';
 
-export default function ReportHeader({ currentDate, onChangeMonth, joinedAt }) {
+export default function ReportHeader({ currentDate, onChangeMonth, joinedAt, onPressYearMonth }) {
     const date = dayjs(currentDate).startOf('month');
 
     const yearText = date.format('YYYY년');
@@ -40,14 +40,12 @@ export default function ReportHeader({ currentDate, onChangeMonth, joinedAt }) {
 
     return (
         <View className="px-5 py-4 flex-row justify-between items-center">
-            <View>
-                <AppText variant="M500" className="text-gr500">
-                    {yearText}
-                </AppText>
-                <AppText variant="H3" className="mt-1 text-bk">
-                    {monthText}
-                </AppText>
-            </View>
+            <TouchableOpacity onPress={onPressYearMonth}>
+                <View>
+                    <AppText variant="M500" className="text-gr500">{yearText}</AppText>
+                    <AppText variant="H3" className="mt-1 text-bk">{monthText}</AppText>
+                </View>
+            </TouchableOpacity>
 
             <View className="flex-row items-center gap-3">
                 <TouchableOpacity onPress={handlePrev}>

--- a/src/features/report/screens/ReportScreen.jsx
+++ b/src/features/report/screens/ReportScreen.jsx
@@ -1,33 +1,34 @@
-import React, { useMemo, useState, useEffect, useCallback } from 'react';
-import { ScrollView } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import dayjs from 'dayjs';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import React, {useMemo, useState, useEffect, useCallback} from "react";
+import {ScrollView} from "react-native";
+import {SafeAreaView} from "react-native-safe-area-context";
+import dayjs from "dayjs";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
 
-import ReportHeader from '../components/ReportHeader';
-import ReportHeroCard from '../components/ReportHeroCard';
-import ReportTotalSection from '../components/ReportTotalSection';
-import ReportCategoryCard from '../components/ReportCategoryCard';
+import ReportHeader from "../components/ReportHeader";
+import ReportHeroCard from "../components/ReportHeroCard";
+import ReportTotalSection from "../components/ReportTotalSection";
+import ReportCategoryCard from "../components/ReportCategoryCard";
 
-import { getReport } from '../api/reportApi';
+import {getReport} from "../api/reportApi";
+import YearMonthWheelModal from "../../todo/components/RepeatSettingsSection/wheel/YearMonthWheelModal";
 
 function mapAttendanceIconToCaseType(attendanceIcon) {
-    if (attendanceIcon === 'EXCELLENT') return 'A';
-    if (attendanceIcon === 'GOOD') return 'B';
-    return 'C';
+    if (attendanceIcon === "EXCELLENT") return "A";
+    if (attendanceIcon === "GOOD") return "B";
+    return "C";
 }
 
-const ZERO_REPORT = { attendanceIcon: 'POOR', categories: [] };
+const ZERO_REPORT = {attendanceIcon: "POOR", categories: []};
 
 export default function ReportScreen() {
-    const [currentDate, setCurrentDate] = useState(dayjs().startOf('month'));
+    const [currentDate, setCurrentDate] = useState(dayjs().startOf("month"));
     const [reportData, setReportData] = useState(null);
 
-    const [nickname, setNickname] = useState('');
-    const [joinedMonth, setJoinedMonth] = useState(null); // "YYYY-MM"
+    const [nickname, setNickname] = useState("");
+    const [joinedMonth, setJoinedMonth] = useState(null);
 
-    const lastMonth = useMemo(() => dayjs().subtract(1, 'month').startOf('month'), []);
+    const lastMonth = useMemo(() => dayjs().subtract(1, "month").startOf("month"), []);
 
     useEffect(() => {
         let alive = true;
@@ -45,34 +46,44 @@ export default function ReportScreen() {
         };
     }, []);
 
-
-    const joinedMonthDate = useMemo(() => {
-        return joinedMonth ? dayjs(joinedMonth, 'YYYY-MM').startOf('month') : null;
-    }, [joinedMonth]);
+    const joinedMonthDate = useMemo(
+        () => (joinedMonth ? dayjs(joinedMonth, "YYYY-MM").startOf("month") : null),
+        [joinedMonth]
+    );
 
     const maxMonth = useMemo(() => {
+        const lastMonth = dayjs().subtract(1, "month").startOf("month");
         if (!joinedMonthDate) return lastMonth;
-        return joinedMonthDate.isAfter(lastMonth, 'month') ? joinedMonthDate : lastMonth;
-    }, [joinedMonthDate, lastMonth]);
+
+        // 가입월이 지난달보다 "더 최근"이면(=이번달 가입) 가입월까지 허용
+        return joinedMonthDate.isAfter(lastMonth, "month") ? joinedMonthDate : lastMonth;
+    }, [joinedMonthDate]);
+
+
+
+    useEffect(() => {
+        if (!joinedMonthDate) return;
+        if (currentDate.isAfter(maxMonth, "month")) setCurrentDate(maxMonth);
+        if (currentDate.isBefore(joinedMonthDate, "month")) setCurrentDate(joinedMonthDate);
+    }, [joinedMonthDate, maxMonth]);
 
     const year = useMemo(() => dayjs(currentDate).year(), [currentDate]);
     const month = useMemo(() => dayjs(currentDate).month() + 1, [currentDate]);
-    const viewingYM = useMemo(() => dayjs(currentDate).format('YYYY-MM'), [currentDate]);
+    const viewingYM = useMemo(() => dayjs(currentDate).format("YYYY-MM"), [currentDate]);
 
     const isJoinedMonthView = useMemo(() => {
-        return joinedMonth ? viewingYM === joinedMonth : false;
-    }, [viewingYM, joinedMonth]);
+        if (!joinedMonthDate) return false;
+        return dayjs(currentDate).isSame(joinedMonthDate, "month");
+    }, [currentDate, joinedMonthDate]);
 
     const handleChangeMonth = useCallback(
         (nextDate) => {
-            const next = dayjs(nextDate).startOf('month');
-
-            if (next.isAfter(maxMonth, 'month')) return;
-            if (joinedMonthDate && next.isBefore(joinedMonthDate, 'month')) return;
-
+            const next = dayjs(nextDate).startOf("month");
+            if (joinedMonthDate && next.isBefore(joinedMonthDate, "month")) return;
+            if (next.isAfter(maxMonth, "month")) return;
             setCurrentDate(next);
         },
-        [maxMonth, joinedMonthDate]
+        [joinedMonthDate, maxMonth]
     );
 
     useEffect(() => {
@@ -87,7 +98,7 @@ export default function ReportScreen() {
                 return;
             }
 
-            if (dayjs(currentDate).isAfter(maxMonth, 'month')) {
+            if (dayjs(currentDate).isAfter(maxMonth, "month")) {
                 if (!alive) return;
                 setReportData(null);
                 return;
@@ -103,12 +114,14 @@ export default function ReportScreen() {
             }
         })();
 
-        return () => { alive = false; };
+        return () => {
+            alive = false;
+        };
     }, [joinedMonthDate, isJoinedMonthView, currentDate, maxMonth, year, month]);
 
     const report = useMemo(() => {
         const payload = reportData?.data ?? reportData;
-        if (!payload) return { caseType: 'C', categories: [] };
+        if (!payload) return {caseType: "C", categories: []};
 
         const caseType = mapAttendanceIconToCaseType(payload.attendanceIcon);
 
@@ -116,15 +129,15 @@ export default function ReportScreen() {
             ? payload.categories
                 .filter(Boolean)
                 .map((c) => {
-                    const total = Number(c?.['totalTodos'] ?? 0);
-                    const success = Number(c?.['completedTodos'] ?? 0);
+                    const total = Number(c?.["totalTodos"] ?? 0);
+                    const success = Number(c?.["completedTodos"] ?? 0);
                     const fail =
-                        c?.['incompleteTodos'] != null
-                            ? Number(c?.['incompleteTodos'])
+                        c?.["incompleteTodos"] != null
+                            ? Number(c?.["incompleteTodos"])
                             : Math.max(0, total - success);
 
                     return {
-                        name: c?.['categoryName'] ?? '카테고리',
+                        name: c?.["categoryName"] ?? "카테고리",
                         total,
                         success,
                         fail,
@@ -132,7 +145,7 @@ export default function ReportScreen() {
                 })
             : [];
 
-        return { caseType, categories };
+        return {caseType, categories};
     }, [reportData]);
 
     const totals = useMemo(() => {
@@ -143,21 +156,58 @@ export default function ReportScreen() {
                 acc.failed += cur.fail;
                 return acc;
             },
-            { total: 0, completed: 0, failed: 0 }
+            {total: 0, completed: 0, failed: 0}
         );
     }, [report.categories]);
 
+    const [isYMModalOpen, setIsYMModalOpen] = useState(false);
+
+    const openYMModal = useCallback(() => setIsYMModalOpen(true), []);
+    const closeYMModal = useCallback(() => setIsYMModalOpen(false), []);
+
+    const yearFrom = joinedMonthDate ? joinedMonthDate.year() : currentDate.year();
+    const yearTo = maxMonth.year();
+
+    const handleConfirmYM = useCallback(
+        (year, month) => {
+            const next = dayjs().year(year).month(month - 1).startOf("month");
+
+            if (joinedMonthDate && next.isBefore(joinedMonthDate, "month")) return;
+            if (next.isAfter(maxMonth, "month")) return;
+
+            setCurrentDate(next);
+            setIsYMModalOpen(false);
+        },
+        [joinedMonthDate, maxMonth]
+    );
+
+    const isSelectableMonth = useCallback(
+        (y, m) => {
+            const target = dayjs().year(y).month(m - 1).startOf("month");
+            if (joinedMonthDate && target.isBefore(joinedMonthDate, "month")) return false;
+            if (target.isAfter(maxMonth, "month")) return false;
+            return true;
+        },
+        [joinedMonthDate, maxMonth]
+    );
+
+    const isMoveDisabled = useCallback(
+        (y, m) => !isSelectableMonth(y, m),
+        [isSelectableMonth]
+    );
+
     return (
-        <SafeAreaView className="flex-1 bg-wt" edges={['top']}>
+        <SafeAreaView className="flex-1 bg-wt" edges={["top"]}>
             <ReportHeader
                 currentDate={currentDate}
                 onChangeMonth={handleChangeMonth}
-                joinedAt={joinedMonth ?? ''}
+                joinedAt={joinedMonth ?? ""}
+                onPressYearMonth={openYMModal}
             />
 
             <ScrollView
                 className="flex-1"
-                contentContainerStyle={{ paddingBottom: 32 }}
+                contentContainerStyle={{paddingBottom: 32}}
                 showsVerticalScrollIndicator={false}
             >
                 <ReportHeroCard caseType={report.caseType} nickname={nickname} />
@@ -170,6 +220,16 @@ export default function ReportScreen() {
 
                 <ReportCategoryCard data={report.categories} />
             </ScrollView>
+
+            <YearMonthWheelModal
+                visible={isYMModalOpen}
+                initialYear={currentDate.year()}
+                initialMonth={currentDate.month() + 1}
+                onCancel={closeYMModal}
+                onConfirm={handleConfirmYM}
+                yearFrom={joinedMonthDate ? joinedMonthDate.year() : currentDate.year()}
+                yearTo={maxMonth.year()}
+            />
         </SafeAreaView>
     );
 }

--- a/src/features/todo/components/RepeatSettingsSection/wheel/WheelColumn.jsx
+++ b/src/features/todo/components/RepeatSettingsSection/wheel/WheelColumn.jsx
@@ -15,7 +15,7 @@ export default function WheelColumn({
   visibleCount = VISIBLE,
   activeTextStyle,
   textStyle,
-  containerStyle,
+  containerStyle, isDisabled,
 }) {
   const ref = useRef(null);
   const padding = Math.floor(visibleCount / 2) * itemHeight;
@@ -32,12 +32,26 @@ export default function WheelColumn({
     (e) => {
       const y = e.nativeEvent.contentOffset.y;
       const idx = Math.round(y / itemHeight);
+
+        if (isDisabled?.(idx)) {
+            ref.current?.scrollToOffset({
+                offset: selectedIndex * itemHeight,
+                animated: true,
+            });
+            return;
+        }
+
       onChangeIndex?.(idx);
     },
-    [itemHeight, onChangeIndex]
+    [itemHeight, onChangeIndex, isDisabled, selectedIndex]
   );
 
-  return (
+  const handleSelect = (index) => {
+      if (isDisabled?.(index)) return;
+      onChangeIndex(index);
+  };
+
+    return (
     <View
       style={[
         styles.col,
@@ -62,20 +76,22 @@ export default function WheelColumn({
         })}
         renderItem={({item, index}) => {
           const isActive = index === selectedIndex;
-          return (
-            <View style={[styles.item, {height: itemHeight}]}>
-              <Text
-                style={[
-                  styles.text,
-                  textStyle,
-                  isActive && styles.textActive,
-                  isActive && activeTextStyle,
-                ]}
-              >
-                {renderLabel(item)}
-              </Text>
-            </View>
-          );
+          const disabled = isDisabled?.(index);
+            return (
+                <View style={[styles.item, {height: itemHeight}]}>
+                    <Text
+                        style={[
+                            styles.text,
+                            textStyle,
+                            isActive && styles.textActive,
+                            isActive && activeTextStyle,
+                            disabled && { color: "#C4C4C3" },
+                        ]}
+                    >
+                        {renderLabel(item)}
+                    </Text>
+                </View>
+            );
         }}
       />
 

--- a/src/features/todo/components/RepeatSettingsSection/wheel/YearMonthWheelModal.jsx
+++ b/src/features/todo/components/RepeatSettingsSection/wheel/YearMonthWheelModal.jsx
@@ -33,7 +33,11 @@ export default function YearMonthWheelModal({
   const years = useMemo(() => {
     const from = yearFrom ?? baseYear - 50;
     const to = yearTo ?? baseYear + 50;
-    return range(from, to);
+
+    const a = Math.min(from, to);
+    const b = Math.max(from, to);
+
+    return range(a, b);
   }, [baseYear, yearFrom, yearTo]);
 
   const months = useMemo(() => range(1, 12), []);
@@ -43,8 +47,12 @@ export default function YearMonthWheelModal({
 
   useEffect(() => {
     if (!visible) return;
-    setYearIdx(Math.max(0, years.indexOf(initialYear)));
-    setMonthIdx(Math.max(0, months.indexOf(initialMonth)));
+
+    const yi = years.indexOf(initialYear);
+    const mi = months.indexOf(initialMonth);
+
+    setYearIdx(yi >= 0 ? yi : 0);
+    setMonthIdx(mi >= 0 ? mi : 0);
   }, [visible, initialYear, initialMonth, years, months]);
 
   const handleMove = useCallback(() => {

--- a/src/features/todo/screens/Home/HomeScreen.jsx
+++ b/src/features/todo/screens/Home/HomeScreen.jsx
@@ -424,15 +424,27 @@ export default function HomeScreen({navigation, route}) {
   );
 
   // 캘린더 연동
+  const appliedInitialDateRef = useRef(null); // 마지막으로 적용한 initialDate
+  const skipResetOnceRef = useRef(false);     // 캘린더에서 넘어온 직후 1회 리셋 방지
+
   useFocusEffect(
       useCallback(() => {
         const dateStr = route?.params?.initialDate;
-        if (!dateStr) return;
 
-        const [y, m, d] = String(dateStr).split("-").map(Number);
-        if (!y || !m || !d) return;
-
-        setCurrentDate(new Date(y, m - 1, d));
+        if (dateStr && appliedInitialDateRef.current !== dateStr) {
+          const [y, m, d] = String(dateStr).split("-").map(Number);
+          if (y && m && d) {
+            appliedInitialDateRef.current = dateStr;
+            skipResetOnceRef.current = true;
+            setCurrentDate(new Date(y, m - 1, d));
+          }
+          return;
+        }
+        if (skipResetOnceRef.current) {
+          skipResetOnceRef.current = false;
+          return;
+        }
+        setCurrentDate(new Date());
       }, [route?.params?.initialDate])
   );
 

--- a/src/features/todo/screens/Home/HomeScreen.jsx
+++ b/src/features/todo/screens/Home/HomeScreen.jsx
@@ -40,6 +40,7 @@ import TodoBoardSection from "../../components/TodoBoardSection";
 import FCMInitializer from "../../../../notifications/components/FCMInitializer";
 
 const {width, height} = Dimensions.get("window");
+import { useFocusEffect } from "@react-navigation/native";
 
 // ✅ 오늘 날짜(로컬 기준) YYYY-MM-DD
 function formatYYYYMMDD(dateObj) {
@@ -197,7 +198,7 @@ function pickRandomDifferent(list, prev, fallback = "") {
   return next ?? fallback;
 }
 
-export default function HomeScreen({navigation}) {
+export default function HomeScreen({navigation, route}) {
   const {open, close} = useModalStore();
 
   const [shouldInitNotifications, setShouldInitNotifications] = useState(false);
@@ -420,6 +421,19 @@ export default function HomeScreen({navigation}) {
       editor.openEditor?.(payload);
     },
     [editor],
+  );
+
+  // 캘린더 연동
+  useFocusEffect(
+      useCallback(() => {
+        const dateStr = route?.params?.initialDate;
+        if (!dateStr) return;
+
+        const [y, m, d] = String(dateStr).split("-").map(Number);
+        if (!y || !m || !d) return;
+
+        setCurrentDate(new Date(y, m - 1, d));
+      }, [route?.params?.initialDate])
   );
 
   return (


### PR DESCRIPTION
## **📋 작업 개요**
- 홈/리포트 연월이동 모달 연동
- 알람 설정 시스템 환경 연동

## **📝 작업 상세 설명**
- 연·월 이동 모달로 조회 가능 범위 내에서만 이동 처리
- 가입 월은 데이터 없이도 조회 가능, 최대 조회는 지난달까지
- 화면 재진입 및 Today 클릭 시 날짜를 오늘로 초기화
- OS 알림 권한에 따라 푸시 알림 토글 상태 자동 동기화
- 푸시 알림 OFF 시 하위 알림 비활성화, ON 시 튀김 알림 기본 활성화
- 알림 권한 미허용 상태에서 푸시 알림 ON 시 설정 화면 이동

## **추가 사항**
- 리포트 연월이동 모달 예외처리 추가 필요
- 알람 설정 api 연동 필요
- 리포트 변동사항 수정 필요
