### PR TITLE
chore: report modal

### DIFF
--- a/src/features/auth/queries/socialLogin/socialLoginApi.js
+++ b/src/features/auth/queries/socialLogin/socialLoginApi.js
@@ -5,6 +5,7 @@ import { saveAccessToken, saveRefreshToken } from "../../../../shared/lib/storag
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
 import { STEP_KEY } from "../../../../shared/constants/onboardingStep";
+import dayjs from "dayjs";
 
 async function persistLoginResult(data, deviceId) {
     await Promise.all([
@@ -24,6 +25,12 @@ async function persistLoginResult(data, deviceId) {
             SecureStore.setItemAsync("nickname", nick),
         ]);
     }
+    const joinedMonth =
+        data?.user?.createdAt
+            ? dayjs(data.user.createdAt).format("YYYY-MM")
+            : dayjs().format("YYYY-MM");
+
+    await AsyncStorage.setItem("joinedMonth", joinedMonth);
 
     await AsyncStorage.setItem(STEP_KEY, String(data?.onboardingStatus ?? ""));
 }

--- a/src/features/report/screens/ReportScreen.jsx
+++ b/src/features/report/screens/ReportScreen.jsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState, useEffect, useCallback} from "react";
+import React, {useMemo, useState, useEffect, useCallback, useRef} from "react";
 import {ScrollView} from "react-native";
 import {SafeAreaView} from "react-native-safe-area-context";
 import {useFocusEffect} from "@react-navigation/native";
@@ -13,11 +13,23 @@ import ReportCategoryCard from "../components/ReportCategoryCard";
 
 import {getReport} from "../api/reportApi";
 import YearMonthWheelModal from "../../todo/components/RepeatSettingsSection/wheel/YearMonthWheelModal";
-
 function mapAttendanceIconToCaseType(attendanceIcon) {
     if (attendanceIcon === "EXCELLENT") return "A";
     if (attendanceIcon === "GOOD") return "B";
     return "C";
+}
+
+function parseJoinedMonthToDate(input) {
+    if (!input) return null;
+    const s = String(input).trim();
+    const m = /(\d{4})-(\d{1,2})/.exec(s);
+    if (!m) return null;
+
+    const y = Number(m[1]);
+    const mo = Number(m[2]);
+    if (!y || mo < 1 || mo > 12) return null;
+
+    return dayjs().year(y).month(mo - 1).startOf("month");
 }
 
 export default function ReportScreen() {
@@ -28,13 +40,15 @@ export default function ReportScreen() {
     const [reportData, setReportData] = useState(null);
 
     const [nickname, setNickname] = useState("");
-    const [joinedMonth, setJoinedMonth] = useState(null);
+    const [joinedMonth, setJoinedMonth] = useState("");
 
-    const joinedMonthDate = useMemo(
-        () => (joinedMonth ? dayjs(joinedMonth, "YYYY-MM").startOf("month") : null),
-        [joinedMonth]
-    );
+    const [isYMModalOpen, setIsYMModalOpen] = useState(false);
+    const openYMModal = useCallback(() => setIsYMModalOpen(true), []);
+    const closeYMModal = useCallback(() => setIsYMModalOpen(false), []);
 
+    const joinedMonthDate = useMemo(() => parseJoinedMonthToDate(joinedMonth), [joinedMonth]);
+
+    // 정책: 회원가입월 ~ 이번달. 표시는 "이전달, 이번달" 중 가입월 이후만 허용
     const allowedMonths = useMemo(() => {
         const base = [prevMonth, nowMonth];
         if (!joinedMonthDate) return base;
@@ -49,62 +63,110 @@ export default function ReportScreen() {
     );
 
     useEffect(() => {
-        const key = dayjs(currentDate).format("YYYY-MM");
+        const key = currentDate.format("YYYY-MM");
         if (!allowedMonthKeys.has(key)) setCurrentDate(allowedMonths[allowedMonths.length - 1]);
     }, [allowedMonthKeys, allowedMonths, currentDate]);
 
-    const year = useMemo(() => dayjs(currentDate).year(), [currentDate]);
-    const month = useMemo(() => dayjs(currentDate).month() + 1, [currentDate]);
+    const year = useMemo(() => currentDate.year(), [currentDate]);
+    const month = useMemo(() => currentDate.month() + 1, [currentDate]);
 
-    const refreshLocalUser = useCallback(async () => {
-        const jm = await AsyncStorage.getItem("joinedMonth");
-        if (jm) setJoinedMonth(jm);
+    const handleChangeMonth = useCallback(
+        (nextDate) => {
+            const next = dayjs(nextDate).startOf("month");
+            if (!allowedMonthKeys.has(next.format("YYYY-MM"))) return;
+            setCurrentDate(next);
+        },
+        [allowedMonthKeys]
+    );
+
+    const handleConfirmYM = useCallback(
+        (y, m) => {
+            const next = dayjs().year(y).month(m - 1).startOf("month");
+            if (!allowedMonthKeys.has(next.format("YYYY-MM"))) return;
+            setCurrentDate(next);
+            setIsYMModalOpen(false);
+        },
+        [allowedMonthKeys]
+    );
+
+    const availableYMs = useMemo(
+        () => allowedMonths.map((d) => ({year: d.year(), month: d.month() + 1})),
+        [allowedMonths]
+    );
+
+    const lastFetchKeyRef = useRef("");
+
+    const refreshOnFocus = useCallback(async () => {
+        const jmRaw = await AsyncStorage.getItem("joinedMonth");
+        const jmDate = parseJoinedMonthToDate(jmRaw);
+
+        const joinedAtStr = jmDate ? jmDate.format("YYYY-MM") : (jmRaw ? String(jmRaw) : "");
+        setJoinedMonth(joinedAtStr);
 
         const nick = await SecureStore.getItemAsync("nickname");
         if (nick) setNickname(nick);
-    }, []);
 
-    const fetchReport = useCallback(async () => {
-        const key = dayjs(currentDate).format("YYYY-MM");
-        if (!allowedMonthKeys.has(key)) {
-            setReportData(null);
-            return;
-        }
+        const base = [prevMonth, nowMonth];
+        const allowed = jmDate
+            ? (base.filter((d) => !d.isBefore(jmDate, "month")).length
+                ? base.filter((d) => !d.isBefore(jmDate, "month"))
+                : [nowMonth])
+            : base;
+
+        const allowedKeys = new Set(allowed.map((d) => d.format("YYYY-MM")));
+
+        let target = currentDate;
+        if (!allowedKeys.has(target.format("YYYY-MM"))) target = allowed[allowed.length - 1];
+
+        const fetchKey = `${target.format("YYYY-MM")}`;
+        if (lastFetchKeyRef.current === fetchKey) return;
+        lastFetchKeyRef.current = fetchKey;
+
+        setCurrentDate(target);
 
         try {
-            const data = await getReport(year, month);
+            const data = await getReport(target.year(), target.month() + 1);
             setReportData(data);
         } catch {
             setReportData(null);
         }
-    }, [allowedMonthKeys, currentDate, year, month]);
+    }, [currentDate, nowMonth, prevMonth]);
 
     useFocusEffect(
         useCallback(() => {
             let alive = true;
 
             (async () => {
-                await refreshLocalUser();
-                if (!alive) return;
-
-                await fetchReport();
+                try {
+                    await refreshOnFocus();
+                } finally {
+                    if (!alive) return;
+                }
             })();
 
             return () => {
                 alive = false;
             };
-        }, [refreshLocalUser, fetchReport])
+        }, [refreshOnFocus])
     );
 
-    const handleChangeMonth = useCallback(
-        (nextDate) => {
-            const next = dayjs(nextDate).startOf("month");
-            const key = next.format("YYYY-MM");
-            if (!allowedMonthKeys.has(key)) return;
-            setCurrentDate(next);
-        },
-        [allowedMonthKeys]
-    );
+    useEffect(() => {
+        const key = currentDate.format("YYYY-MM");
+        if (!allowedMonthKeys.has(key)) return;
+
+        const fetchKey = `${key}`;
+        if (lastFetchKeyRef.current === fetchKey) return;
+        lastFetchKeyRef.current = fetchKey;
+
+        (async () => {
+            try {
+                const data = await getReport(year, month);
+                setReportData(data);
+            } catch {
+                setReportData(null);
+            }
+        })();
+    }, [currentDate, allowedMonthKeys, year, month]);
 
     const report = useMemo(() => {
         const payload = reportData?.data ?? reportData;
@@ -118,8 +180,7 @@ export default function ReportScreen() {
                 .map((c) => {
                     const total = Number(c?.totalTodos ?? 0);
                     const success = Number(c?.completedTodos ?? 0);
-                    const fail =
-                        c?.incompleteTodos != null ? Number(c.incompleteTodos) : Math.max(0, total - success);
+                    const fail = c?.incompleteTodos != null ? Number(c.incompleteTodos) : Math.max(0, total - success);
 
                     return {
                         name: c?.categoryName ?? "카테고리",
@@ -145,33 +206,6 @@ export default function ReportScreen() {
         );
     }, [report.categories]);
 
-    const [isYMModalOpen, setIsYMModalOpen] = useState(false);
-
-    const openYMModal = useCallback(() => setIsYMModalOpen(true), []);
-    const closeYMModal = useCallback(() => setIsYMModalOpen(false), []);
-
-    const yearFrom = useMemo(() => {
-        const min = allowedMonths[0];
-        return min.year();
-    }, [allowedMonths]);
-
-    const yearTo = useMemo(() => {
-        const max = allowedMonths[allowedMonths.length - 1];
-        return max.year();
-    }, [allowedMonths]);
-
-    const handleConfirmYM = useCallback(
-        (y, m) => {
-            const next = dayjs().year(y).month(m - 1).startOf("month");
-            const key = next.format("YYYY-MM");
-            if (!allowedMonthKeys.has(key)) return;
-
-            setCurrentDate(next);
-            setIsYMModalOpen(false);
-        },
-        [allowedMonthKeys]
-    );
-
     return (
         <SafeAreaView className="flex-1 bg-wt" edges={["top"]}>
             <ReportHeader
@@ -181,30 +215,21 @@ export default function ReportScreen() {
                 onPressYearMonth={openYMModal}
             />
 
-            <ScrollView
-                className="flex-1"
-                contentContainerStyle={{paddingBottom: 32}}
-                showsVerticalScrollIndicator={false}
-            >
+            <ScrollView className="flex-1" contentContainerStyle={{paddingBottom: 32}} showsVerticalScrollIndicator={false}>
                 <ReportHeroCard caseType={report.caseType} nickname={nickname} />
 
-                <ReportTotalSection
-                    total={totals.total}
-                    completed={totals.completed}
-                    failed={totals.failed}
-                />
+                <ReportTotalSection total={totals.total} completed={totals.completed} failed={totals.failed} />
 
                 <ReportCategoryCard data={report.categories} />
             </ScrollView>
 
             <YearMonthWheelModal
                 visible={isYMModalOpen}
-                initialYear={currentDate.year()}
-                initialMonth={currentDate.month() + 1}
+                initialYear={allowedMonths[allowedMonths.length - 1].year()}
+                initialMonth={allowedMonths[allowedMonths.length - 1].month() + 1}
                 onCancel={closeYMModal}
                 onConfirm={handleConfirmYM}
-                yearFrom={yearFrom}
-                yearTo={yearTo}
+                availableYMs={availableYMs}
             />
         </SafeAreaView>
     );

--- a/src/features/report/screens/ReportScreen.jsx
+++ b/src/features/report/screens/ReportScreen.jsx
@@ -1,6 +1,7 @@
 import React, {useMemo, useState, useEffect, useCallback} from "react";
 import {ScrollView} from "react-native";
 import {SafeAreaView} from "react-native-safe-area-context";
+import {useFocusEffect} from "@react-navigation/native";
 import dayjs from "dayjs";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
@@ -19,105 +20,91 @@ function mapAttendanceIconToCaseType(attendanceIcon) {
     return "C";
 }
 
-const ZERO_REPORT = {attendanceIcon: "POOR", categories: []};
-
 export default function ReportScreen() {
-    const [currentDate, setCurrentDate] = useState(dayjs().startOf("month"));
+    const nowMonth = useMemo(() => dayjs().startOf("month"), []);
+    const prevMonth = useMemo(() => dayjs().subtract(1, "month").startOf("month"), []);
+
+    const [currentDate, setCurrentDate] = useState(nowMonth);
     const [reportData, setReportData] = useState(null);
 
     const [nickname, setNickname] = useState("");
     const [joinedMonth, setJoinedMonth] = useState(null);
-
-    const lastMonth = useMemo(() => dayjs().subtract(1, "month").startOf("month"), []);
-
-    useEffect(() => {
-        let alive = true;
-
-        (async () => {
-            const jm = await AsyncStorage.getItem("joinedMonth");
-            if (alive && jm) setJoinedMonth(jm);
-
-            const nick = await SecureStore.getItemAsync("nickname");
-            if (alive && nick) setNickname(nick);
-        })();
-
-        return () => {
-            alive = false;
-        };
-    }, []);
 
     const joinedMonthDate = useMemo(
         () => (joinedMonth ? dayjs(joinedMonth, "YYYY-MM").startOf("month") : null),
         [joinedMonth]
     );
 
-    const maxMonth = useMemo(() => {
-        const lastMonth = dayjs().subtract(1, "month").startOf("month");
-        if (!joinedMonthDate) return lastMonth;
+    const allowedMonths = useMemo(() => {
+        const base = [prevMonth, nowMonth];
+        if (!joinedMonthDate) return base;
 
-        // 가입월이 지난달보다 "더 최근"이면(=이번달 가입) 가입월까지 허용
-        return joinedMonthDate.isAfter(lastMonth, "month") ? joinedMonthDate : lastMonth;
-    }, [joinedMonthDate]);
+        const filtered = base.filter((d) => !d.isBefore(joinedMonthDate, "month"));
+        return filtered.length ? filtered : [nowMonth];
+    }, [joinedMonthDate, prevMonth, nowMonth]);
 
-
+    const allowedMonthKeys = useMemo(
+        () => new Set(allowedMonths.map((d) => d.format("YYYY-MM"))),
+        [allowedMonths]
+    );
 
     useEffect(() => {
-        if (!joinedMonthDate) return;
-        if (currentDate.isAfter(maxMonth, "month")) setCurrentDate(maxMonth);
-        if (currentDate.isBefore(joinedMonthDate, "month")) setCurrentDate(joinedMonthDate);
-    }, [joinedMonthDate, maxMonth]);
+        const key = dayjs(currentDate).format("YYYY-MM");
+        if (!allowedMonthKeys.has(key)) setCurrentDate(allowedMonths[allowedMonths.length - 1]);
+    }, [allowedMonthKeys, allowedMonths, currentDate]);
 
     const year = useMemo(() => dayjs(currentDate).year(), [currentDate]);
     const month = useMemo(() => dayjs(currentDate).month() + 1, [currentDate]);
-    const viewingYM = useMemo(() => dayjs(currentDate).format("YYYY-MM"), [currentDate]);
 
-    const isJoinedMonthView = useMemo(() => {
-        if (!joinedMonthDate) return false;
-        return dayjs(currentDate).isSame(joinedMonthDate, "month");
-    }, [currentDate, joinedMonthDate]);
+    const refreshLocalUser = useCallback(async () => {
+        const jm = await AsyncStorage.getItem("joinedMonth");
+        if (jm) setJoinedMonth(jm);
+
+        const nick = await SecureStore.getItemAsync("nickname");
+        if (nick) setNickname(nick);
+    }, []);
+
+    const fetchReport = useCallback(async () => {
+        const key = dayjs(currentDate).format("YYYY-MM");
+        if (!allowedMonthKeys.has(key)) {
+            setReportData(null);
+            return;
+        }
+
+        try {
+            const data = await getReport(year, month);
+            setReportData(data);
+        } catch {
+            setReportData(null);
+        }
+    }, [allowedMonthKeys, currentDate, year, month]);
+
+    useFocusEffect(
+        useCallback(() => {
+            let alive = true;
+
+            (async () => {
+                await refreshLocalUser();
+                if (!alive) return;
+
+                await fetchReport();
+            })();
+
+            return () => {
+                alive = false;
+            };
+        }, [refreshLocalUser, fetchReport])
+    );
 
     const handleChangeMonth = useCallback(
         (nextDate) => {
             const next = dayjs(nextDate).startOf("month");
-            if (joinedMonthDate && next.isBefore(joinedMonthDate, "month")) return;
-            if (next.isAfter(maxMonth, "month")) return;
+            const key = next.format("YYYY-MM");
+            if (!allowedMonthKeys.has(key)) return;
             setCurrentDate(next);
         },
-        [joinedMonthDate, maxMonth]
+        [allowedMonthKeys]
     );
-
-    useEffect(() => {
-        let alive = true;
-
-        (async () => {
-            if (!joinedMonthDate) return;
-
-            if (isJoinedMonthView) {
-                if (!alive) return;
-                setReportData(ZERO_REPORT);
-                return;
-            }
-
-            if (dayjs(currentDate).isAfter(maxMonth, "month")) {
-                if (!alive) return;
-                setReportData(null);
-                return;
-            }
-
-            try {
-                const data = await getReport(year, month);
-                if (!alive) return;
-                setReportData(data);
-            } catch {
-                if (!alive) return;
-                setReportData(null);
-            }
-        })();
-
-        return () => {
-            alive = false;
-        };
-    }, [joinedMonthDate, isJoinedMonthView, currentDate, maxMonth, year, month]);
 
     const report = useMemo(() => {
         const payload = reportData?.data ?? reportData;
@@ -129,15 +116,13 @@ export default function ReportScreen() {
             ? payload.categories
                 .filter(Boolean)
                 .map((c) => {
-                    const total = Number(c?.["totalTodos"] ?? 0);
-                    const success = Number(c?.["completedTodos"] ?? 0);
+                    const total = Number(c?.totalTodos ?? 0);
+                    const success = Number(c?.completedTodos ?? 0);
                     const fail =
-                        c?.["incompleteTodos"] != null
-                            ? Number(c?.["incompleteTodos"])
-                            : Math.max(0, total - success);
+                        c?.incompleteTodos != null ? Number(c.incompleteTodos) : Math.max(0, total - success);
 
                     return {
-                        name: c?.["categoryName"] ?? "카테고리",
+                        name: c?.categoryName ?? "카테고리",
                         total,
                         success,
                         fail,
@@ -165,35 +150,26 @@ export default function ReportScreen() {
     const openYMModal = useCallback(() => setIsYMModalOpen(true), []);
     const closeYMModal = useCallback(() => setIsYMModalOpen(false), []);
 
-    const yearFrom = joinedMonthDate ? joinedMonthDate.year() : currentDate.year();
-    const yearTo = maxMonth.year();
+    const yearFrom = useMemo(() => {
+        const min = allowedMonths[0];
+        return min.year();
+    }, [allowedMonths]);
+
+    const yearTo = useMemo(() => {
+        const max = allowedMonths[allowedMonths.length - 1];
+        return max.year();
+    }, [allowedMonths]);
 
     const handleConfirmYM = useCallback(
-        (year, month) => {
-            const next = dayjs().year(year).month(month - 1).startOf("month");
-
-            if (joinedMonthDate && next.isBefore(joinedMonthDate, "month")) return;
-            if (next.isAfter(maxMonth, "month")) return;
+        (y, m) => {
+            const next = dayjs().year(y).month(m - 1).startOf("month");
+            const key = next.format("YYYY-MM");
+            if (!allowedMonthKeys.has(key)) return;
 
             setCurrentDate(next);
             setIsYMModalOpen(false);
         },
-        [joinedMonthDate, maxMonth]
-    );
-
-    const isSelectableMonth = useCallback(
-        (y, m) => {
-            const target = dayjs().year(y).month(m - 1).startOf("month");
-            if (joinedMonthDate && target.isBefore(joinedMonthDate, "month")) return false;
-            if (target.isAfter(maxMonth, "month")) return false;
-            return true;
-        },
-        [joinedMonthDate, maxMonth]
-    );
-
-    const isMoveDisabled = useCallback(
-        (y, m) => !isSelectableMonth(y, m),
-        [isSelectableMonth]
+        [allowedMonthKeys]
     );
 
     return (
@@ -227,8 +203,8 @@ export default function ReportScreen() {
                 initialMonth={currentDate.month() + 1}
                 onCancel={closeYMModal}
                 onConfirm={handleConfirmYM}
-                yearFrom={joinedMonthDate ? joinedMonthDate.year() : currentDate.year()}
-                yearTo={maxMonth.year()}
+                yearFrom={yearFrom}
+                yearTo={yearTo}
             />
         </SafeAreaView>
     );

--- a/src/features/todo/components/RepeatSettingsSection/wheel/YearMonthWheelModal.jsx
+++ b/src/features/todo/components/RepeatSettingsSection/wheel/YearMonthWheelModal.jsx
@@ -1,59 +1,111 @@
 // src/shared/components/wheels/YearMonthWheelModal.jsx
 import React, {useCallback, useEffect, useMemo, useState} from "react";
-import {
-  Modal,
-  Pressable,
-  View,
-  Text,
-  TouchableOpacity,
-  StyleSheet,
-} from "react-native";
+import {Modal, Pressable, View, Text, TouchableOpacity, StyleSheet} from "react-native";
 import WheelColumn from "./WheelColumn";
 import colors from "../../../../../shared/styles/colors";
 
-const range = (from, to) =>
-  Array.from({length: to - from + 1}, (_, i) => from + i);
+const range = (from, to) => Array.from({length: to - from + 1}, (_, i) => from + i);
+
+function toYM(input) {
+  if (!input) return null;
+  if (typeof input === "string") {
+    const m = /^(\d{4})-(\d{1,2})$/.exec(input);
+    if (!m) return null;
+    const y = Number(m[1]);
+    const mo = Number(m[2]);
+    if (!y || mo < 1 || mo > 12) return null;
+    return {y, m: mo};
+  }
+  if (typeof input === "object" && input.year && input.month) {
+    const y = Number(input.year);
+    const mo = Number(input.month);
+    if (!y || mo < 1 || mo > 12) return null;
+    return {y, m: mo};
+  }
+  return null;
+}
 
 export default function YearMonthWheelModal({
-  visible,
-  initialYear,
-  initialMonth, // 1~12
-  onCancel,
-  onConfirm, // (year, month) => void
+                                              visible,
+                                              initialYear,
+                                              initialMonth,
+                                              onCancel,
+                                              onConfirm,
 
-  yearFrom,
-  yearTo,
+                                              yearFrom,
+                                              yearTo,
 
-  // ✅ 스샷 기준 기본값
-  title = "연월 이동",
-  moveText = "이동하기",
-}) {
+                                              availableYMs,
+
+                                              title = "연월 이동",
+                                              moveText = "이동하기",
+                                            }) {
   const baseYear = new Date().getFullYear();
 
+  const available = useMemo(() => {
+    if (!Array.isArray(availableYMs) || availableYMs.length === 0) return null;
+
+    const map = new Map();
+    for (const v of availableYMs) {
+      const ym = toYM(v);
+      if (!ym) continue;
+      if (!map.has(ym.y)) map.set(ym.y, new Set());
+      map.get(ym.y).add(ym.m);
+    }
+
+    const years = Array.from(map.keys()).sort((a, b) => a - b);
+    const monthsByYear = new Map();
+    years.forEach((y) => {
+      const months = Array.from(map.get(y)).sort((a, b) => a - b);
+      monthsByYear.set(y, months);
+    });
+
+    return {years, monthsByYear};
+  }, [availableYMs]);
+
   const years = useMemo(() => {
+    if (Array.isArray(availableYMs)) return available?.years ?? [];
     const from = yearFrom ?? baseYear - 50;
     const to = yearTo ?? baseYear + 50;
-
     const a = Math.min(from, to);
     const b = Math.max(from, to);
-
     return range(a, b);
-  }, [baseYear, yearFrom, yearTo]);
-
-  const months = useMemo(() => range(1, 12), []);
+  }, [available, baseYear, yearFrom, yearTo]);
 
   const [yearIdx, setYearIdx] = useState(0);
   const [monthIdx, setMonthIdx] = useState(0);
+
+  const selectedYear = years[yearIdx] ?? initialYear;
+
+  const months = useMemo(() => {
+    if (available) return available.monthsByYear.get(selectedYear) ?? [];
+    return range(1, 12);
+  }, [available, selectedYear]);
 
   useEffect(() => {
     if (!visible) return;
 
     const yi = years.indexOf(initialYear);
-    const mi = months.indexOf(initialMonth);
+    const nextYearIdx = yi >= 0 ? yi : 0;
 
-    setYearIdx(yi >= 0 ? yi : 0);
-    setMonthIdx(mi >= 0 ? mi : 0);
-  }, [visible, initialYear, initialMonth, years, months]);
+    const nextYear = years[nextYearIdx] ?? initialYear;
+    const list = available ? available.monthsByYear.get(nextYear) ?? [] : months;
+
+    const mi = list.indexOf(initialMonth);
+    const nextMonthIdx = mi >= 0 ? mi : 0;
+
+    setYearIdx(nextYearIdx);
+    setMonthIdx(nextMonthIdx);
+  }, [visible, initialYear, initialMonth, years, available]);
+
+  useEffect(() => {
+    if (!visible) return;
+    if (!months || months.length === 0) {
+      setMonthIdx(0);
+      return;
+    }
+    if (monthIdx > months.length - 1) setMonthIdx(0);
+  }, [visible, months, monthIdx]);
 
   const handleMove = useCallback(() => {
     const y = years[yearIdx] ?? initialYear;
@@ -62,59 +114,49 @@ export default function YearMonthWheelModal({
   }, [years, months, yearIdx, monthIdx, initialYear, initialMonth, onConfirm]);
 
   return (
-    <Modal visible={visible} transparent animationType="fade">
-      {/* dim */}
-      <Pressable style={styles.backdrop} onPress={onCancel} />
+      <Modal visible={visible} transparent animationType="fade">
+        <Pressable style={styles.backdrop} onPress={onCancel} />
 
-      {/* sheet */}
-      <View style={styles.sheet}>
-        {/* header: title + close */}
-        <View style={styles.header}>
-          <View style={styles.headerSide} />
-          <Text style={styles.title}>{title}</Text>
-          <TouchableOpacity
-            activeOpacity={0.8}
-            onPress={onCancel}
-            style={styles.closeBtn}
-            hitSlop={10}
-          >
-            <Text style={styles.closeText}>×</Text>
-          </TouchableOpacity>
-        </View>
+        <View style={styles.sheet}>
+          <View style={styles.header}>
+            <View style={styles.headerSide} />
+            <Text style={styles.title}>{title}</Text>
+            <TouchableOpacity activeOpacity={0.8} onPress={onCancel} style={styles.closeBtn} hitSlop={10}>
+              <Text style={styles.closeText}>×</Text>
+            </TouchableOpacity>
+          </View>
 
-        {/* wheels */}
-        <View style={styles.wheelRow}>
-          <WheelColumn
-            data={years}
-            selectedIndex={yearIdx}
-            onChangeIndex={setYearIdx}
-            renderLabel={(y) => `${y}년`}
-            containerStyle={styles.wheelColBox}
-            textStyle={styles.wheelText}
-            activeTextStyle={styles.wheelTextActive}
-          />
-          <WheelColumn
-            data={months}
-            selectedIndex={monthIdx}
-            onChangeIndex={setMonthIdx}
-            renderLabel={(m) => `${m}월`}
-            containerStyle={styles.wheelColBox}
-            textStyle={styles.wheelText}
-            activeTextStyle={styles.wheelTextActive}
-          />
+          <View style={styles.wheelRow}>
+            <WheelColumn
+                data={years}
+                selectedIndex={yearIdx}
+                onChangeIndex={(idx) => {
+                  setYearIdx(idx);
+                  setMonthIdx(0);
+                }}
+                renderLabel={(y) => `${y}년`}
+                containerStyle={styles.wheelColBox}
+                textStyle={styles.wheelText}
+                activeTextStyle={styles.wheelTextActive}
+            />
+            <WheelColumn
+                data={months}
+                selectedIndex={monthIdx}
+                onChangeIndex={setMonthIdx}
+                renderLabel={(m) => `${m}월`}
+                containerStyle={styles.wheelColBox}
+                textStyle={styles.wheelText}
+                activeTextStyle={styles.wheelTextActive}
+            />
+          </View>
+
+          <View style={styles.buttonSection}>
+            <TouchableOpacity activeOpacity={0.9} onPress={handleMove} style={styles.moveBtn}>
+              <Text style={styles.moveBtnText}>{moveText}</Text>
+            </TouchableOpacity>
+          </View>
         </View>
-        {/* bottom CTA */}
-        <View style={styles.buttonSection}>
-          <TouchableOpacity
-            activeOpacity={0.9}
-            onPress={handleMove}
-            style={styles.moveBtn}
-          >
-            <Text style={styles.moveBtnText}>{moveText}</Text>
-          </TouchableOpacity>
-        </View>
-      </View>
-    </Modal>
+      </Modal>
   );
 }
 
@@ -148,7 +190,7 @@ const styles = StyleSheet.create({
     // borderWidth: 1,
     // marginBottom: 12,
   },
-  headerSide: {width: 34, height: 18}, // title center 정렬용 더미
+  headerSide: {width: 34, height: 18},
   title: {
     fontFamily: "Pretendard-SemiBold",
     fontSize: 16,

--- a/src/shared/lib/api.js
+++ b/src/shared/lib/api.js
@@ -39,7 +39,32 @@ api.interceptors.request.use(
 
 /* =========================
  * Response Interceptor (Token Refresh)
+ * 동시 401 시 refresh 한 번만 실행, 나머지는 그 결과를 기다린 뒤 재시도
  * ========================= */
+let refreshPromise = null;
+
+function executeRefresh() {
+    const p = (async () => {
+        const refreshToken = await getRefreshToken();
+        if (!refreshToken) {
+            await deleteTokens();
+            throw new Error("No refresh token");
+        }
+        const { data } = await api.post(
+            "/api/users/token/refresh",
+            { refreshToken },
+            { meta: { skipErrorToast: true } }
+        );
+        await saveAccessToken(data.accessToken);
+        await saveRefreshToken(data.refreshToken);
+        return data.accessToken;
+    })().finally(() => {
+        refreshPromise = null;
+    });
+    refreshPromise = p;
+    return p;
+}
+
 api.interceptors.response.use(
     (res) => res,
     async (error) => {
@@ -47,45 +72,45 @@ api.interceptors.response.use(
 
         if (originalRequest?.url?.includes("/api/users/token/refresh")) {
             await deleteTokens();
+            error.isSessionExpired = true;
             return Promise.reject(error);
         }
 
         if (error.response?.status === 401 && !originalRequest._retry) {
             originalRequest._retry = true;
 
-            const refreshToken = await getRefreshToken();
-            if (!refreshToken) {
-                await deleteTokens();
-                return Promise.reject(error);
-            }
-
+            let newAccessToken;
             try {
-                const { data } = await api.post(
-                    "/api/users/token/refresh",
-                    { refreshToken },
-                    { meta: { skipErrorToast: true } }
-                );
-
-                await saveAccessToken(data.accessToken);
-                await saveRefreshToken(data.refreshToken);
-
-                originalRequest.headers = {
-                    ...(originalRequest.headers || {}),
-                    Authorization: `Bearer ${data.accessToken}`,
-                };
-
-                return api(originalRequest);
+                if (refreshPromise) {
+                    newAccessToken = await refreshPromise;
+                } else {
+                    newAccessToken = await executeRefresh();
+                }
             } catch (e) {
                 await deleteTokens();
+                e.isSessionExpired = true;
                 return Promise.reject(e);
             }
+
+            originalRequest.headers = {
+                ...(originalRequest.headers || {}),
+                Authorization: `Bearer ${newAccessToken}`,
+            };
+            return api(originalRequest);
         }
 
-        // 이하 toast 로직은 그대로
+        // 이하 toast 로직: 재시도(GET) 실패·세션 만료 시 일반 API 토스트 생략
         const method = error?.config?.method?.toLowerCase();
         const skipErrorToast = Boolean(error?.config?.meta?.skipErrorToast);
+        const isRetryRequest = Boolean(originalRequest?._retry);
+        const isSessionExpired = Boolean(error?.isSessionExpired);
 
-        if (!skipErrorToast) {
+        const shouldSkipToast =
+            skipErrorToast ||
+            isSessionExpired ||
+            (isRetryRequest && method === "get"); // 백그라운드 refetch 재시도 실패 시 토스트 생략
+
+        if (!shouldSkipToast) {
             if (method === "get") toast.show(TOAST_MESSAGES.GET_ERROR, { position: "center" });
             else if (["post", "put", "patch", "delete"].includes(method)) {
                 toast.show(TOAST_MESSAGES.MUTATION_ERROR, { position: "center" });


### PR DESCRIPTION
## 📋 작업 개요
- API refresh 토큰 갱신 시 동시 401 레이스 컨디션 수정
- 리포트 연월 이동 정책 주석 보강 (가입월~이번달)

## 📝 변경 사항
- 401 동시 발생 시 refresh 1회만 실행, 나머지는 새 토큰 대기 후 재시도
- 세션 만료 시 일반 API 토스트 미노출 (isSessionExpired)
- 재시도 GET 실패 시 GET 토스트 미노출 (백그라운드 refetch 노이즈 감소)
- ReportScreen allowedMonths 정책 주석 추가
- socialLoginApi joinedMonth·user.createdAt 의존 주석 추가