### PR TITLE
홈 스크롤 통합, 투두 메모 표시, 바텀시트 하단 여백 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,10 @@ yarn-error.*
 # generated native folders
 /ios
 /android
+
+# IDE
+.idea/
+
+# AI assistant configs
+CLAUDE.md
+GEMINI.md

--- a/src/features/todo/components/TodoBoardSection.jsx
+++ b/src/features/todo/components/TodoBoardSection.jsx
@@ -1,6 +1,7 @@
 // src/features/todo/components/TodoBoardSection.jsx
 import React, {useMemo, useState, useCallback} from "react";
-import {Image, ScrollView, StyleSheet, View} from "react-native";
+import {Image, StyleSheet, View} from "react-native";
+import {NestableScrollContainer} from "react-native-draggable-flatlist";
 import TodoCard from "./TodoCard";
 import TodoEditorSheet from "./TodoEditorSheet/TodoEditorSheet";
 import ErrorImage from "../../../shared/assets/png/error-icon.png";
@@ -148,7 +149,7 @@ export default function TodoBoardSection({
 
   return (
     <>
-      <ScrollView
+      <NestableScrollContainer
         style={{flex: 1}}
         contentContainerStyle={{paddingBottom: 36}}
         showsVerticalScrollIndicator={false}
@@ -240,7 +241,7 @@ export default function TodoBoardSection({
             }}
           />
         )}
-      </ScrollView>
+      </NestableScrollContainer>
 
       <TodoEditorSheet
         {...editor.sheetProps}

--- a/src/features/todo/components/TodoBoardSection.jsx
+++ b/src/features/todo/components/TodoBoardSection.jsx
@@ -24,6 +24,7 @@ export default function TodoBoardSection({
   navigation,
   date, // ✅ Home/Calendar에서 넘겨주는 선택 날짜(YYYY-MM-DD)
   isViewingToday,
+  ListHeaderComponent,
 }) {
   const {open, close} = useModalStore();
 
@@ -59,6 +60,7 @@ export default function TodoBoardSection({
         date: t.date,
         recurrenceId: t.recurrenceId,
         occurrenceDate: t.occurrenceDate,
+        memo: t.memo ?? "",
       }));
   }, [rawTodos]);
 
@@ -155,6 +157,7 @@ export default function TodoBoardSection({
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
+        {ListHeaderComponent}
         {shouldShowBoardError ? (
           <View style={styles.errorContainer}>
             <Image

--- a/src/features/todo/components/TodoCard.jsx
+++ b/src/features/todo/components/TodoCard.jsx
@@ -91,77 +91,86 @@ function TodoItem({
 
   return (
     <View style={styles.todoRowWrapper}>
-      {/* 뒤에 깔린 삭제 버튼 */}
-      <View style={styles.todoRightActionContainer}>
-        <TouchableOpacity
-          style={styles.todoDeleteButton}
-          activeOpacity={0.7}
-          onPress={() => onDelete(item)}
-        >
-          <DeleteIcon width={24} height={24} />
-        </TouchableOpacity>
+      {/* 타이틀 row 영역 (스와이프 대상) */}
+      <View style={styles.todoTitleArea}>
+        {/* 뒤에 깔린 삭제 버튼 */}
+        <View style={styles.todoRightActionContainer}>
+          <TouchableOpacity
+            style={styles.todoDeleteButton}
+            activeOpacity={0.7}
+            onPress={() => onDelete(item)}
+          >
+            <DeleteIcon width={24} height={24} />
+          </TouchableOpacity>
 
-        {isViewingToday ? (
-          <TouchableOpacity
-            style={styles.todoTodayButton} // ✅ 스타일 그대로 재사용
-            activeOpacity={0.7}
-            onPress={() => onDoTomorrow?.(item.id)}
+          {isViewingToday ? (
+            <TouchableOpacity
+              style={styles.todoTodayButton}
+              activeOpacity={0.7}
+              onPress={() => onDoTomorrow?.(item.id)}
+            >
+              <TomorrowIcon width={24} height={24} />
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity
+              style={styles.todoTodayButton}
+              activeOpacity={0.7}
+              onPress={() => onDoToday?.(item.id)}
+            >
+              <StartDateIcon width={24} height={24} />
+            </TouchableOpacity>
+          )}
+        </View>
+
+        {/* 앞에서 좌우로 움직이는 투두 row */}
+        <GestureDetector gesture={panGesture}>
+          <Animated.View
+            style={[
+              styles.todoRow,
+              isActive && {backgroundColor: "#F2F2F2"},
+              isOpen && {backgroundColor: "#F2F2F2"},
+              animatedRowStyle,
+            ]}
           >
-            <TomorrowIcon width={24} height={24} />
-          </TouchableOpacity>
-        ) : (
-          <TouchableOpacity
-            style={styles.todoTodayButton}
-            activeOpacity={0.7}
-            onPress={() => onDoToday?.(item.id)}
-          >
-            <StartDateIcon width={24} height={24} />
-          </TouchableOpacity>
-        )}
+            <TouchableOpacity
+              onLongPress={onLongPressDrag}
+              hitSlop={8}
+              style={styles.dragHandleButton}
+            >
+              <DragHandleIcon width={12} />
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              activeOpacity={0.7}
+              style={{flex: 1}}
+              onPress={() => onPressItem?.(item)}
+            >
+              <AppText variant="M500" className="text-bk">
+                {item.title}
+              </AppText>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.todoRadioHitArea}
+              activeOpacity={0.6}
+              onPress={() => onToggleDone(item.id)}
+            >
+              {item.done ? (
+                <TodoRadioOnIcon width={24} height={24} />
+              ) : (
+                <TodoRadioOffIcon width={24} height={24} />
+              )}
+            </TouchableOpacity>
+          </Animated.View>
+        </GestureDetector>
       </View>
 
-      {/* 앞에서 좌우로 움직이는 투두 row */}
-      <GestureDetector gesture={panGesture}>
-        <Animated.View
-          style={[
-            styles.todoRow,
-            isActive && {backgroundColor: "#F2F2F2"},
-            isOpen && {backgroundColor: "#F2F2F2"},
-            animatedRowStyle,
-          ]}
-        >
-          <TouchableOpacity
-            onLongPress={onLongPressDrag}
-            hitSlop={8}
-            style={styles.dragHandleButton}
-          >
-            <DragHandleIcon width={12} />
-          </TouchableOpacity>
-
-          {/* ✅ 텍스트 눌러서 수정 바텀시트 열기 */}
-          <TouchableOpacity
-            activeOpacity={0.7}
-            style={{flex: 1}}
-            onPress={() => onPressItem?.(item)}
-          >
-            <AppText variant="M500" className="text-bk">
-              {item.title}
-            </AppText>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={styles.todoRadioHitArea}
-            activeOpacity={0.6}
-            onPress={() => onToggleDone(item.id)}
-          >
-            {item.done ? (
-              <TodoRadioOnIcon width={24} height={24} />
-            ) : (
-              <TodoRadioOffIcon width={24} height={24} />
-            )}
-          </TouchableOpacity>
-        </Animated.View>
-      </GestureDetector>
+      {/* 메모 영역 (스와이프 안 됨, 타이틀 아래 표시) */}
+      {item.memo ? (
+        <AppText variant="M400" style={styles.memoText}>
+          {item.memo}
+        </AppText>
+      ) : null}
     </View>
   );
 }
@@ -525,9 +534,11 @@ const styles = StyleSheet.create({
 
   /** TodoItem styles */
   todoRowWrapper: {
+    // borderWidth: 1,
+  },
+  todoTitleArea: {
     height: 36,
     justifyContent: "center",
-    // borderWidth: 1,
   },
   todoRow: {
     flexDirection: "row",
@@ -577,5 +588,13 @@ const styles = StyleSheet.create({
     borderColor: "#FF5B22",
     alignItems: "center",
     justifyContent: "center",
+  },
+  memoText: {
+    fontSize: 12,
+    lineHeight: 18,
+    color: colors.gr500,
+    paddingLeft: 30,
+    paddingRight: 6,
+    marginTop: 0,
   },
 });

--- a/src/features/todo/components/TodoCard.jsx
+++ b/src/features/todo/components/TodoCard.jsx
@@ -1,7 +1,7 @@
 // src/features/todo/components/TodoCard.jsx
 import React, {useMemo, useState, useCallback, useEffect} from "react";
 import {View, StyleSheet, TouchableOpacity} from "react-native";
-import DraggableFlatList from "react-native-draggable-flatlist";
+import {NestableDraggableFlatList} from "react-native-draggable-flatlist";
 
 import AppText from "../../../shared/components/AppText";
 import DragHandleIcon from "../assets/svg/DragHandle.svg";
@@ -60,6 +60,8 @@ function TodoItem({
   }, [isOpen, translateX]);
 
   const panGesture = Gesture.Pan()
+    // ✅ 드래그 중이면 스와이프 비활성화 (DraggableFlatList 우선)
+    .enabled(!isActive)
     // ✅ 가로로 확실히 움직일 때만 스와이프를 "활성화"
     .activeOffsetX([-8, 8])
     // ✅ 세로로 조금만 움직여도 스와이프는 "실패" → ScrollView가 스크롤 우선
@@ -393,7 +395,7 @@ export default function TodoCard({
 
         {isOpen && (
           <View style={styles.listArea}>
-            <DraggableFlatList
+            <NestableDraggableFlatList
               data={sectionTodos}
               keyExtractor={(item) => item.id}
               onDragEnd={({data}) => handleDragEnd(category.categoryId, data)}
@@ -418,7 +420,6 @@ export default function TodoCard({
                   } // ✅ 추가
                 />
               )}
-              scrollEnabled={false} // ✅ 섹션 안에서 스크롤 안 하고, Home 전체 스크롤로(원하면 부모에 ScrollView)
             />
           </View>
         )}

--- a/src/features/todo/components/TodoEditorSheet/AlarmTimeSettingsSection.jsx
+++ b/src/features/todo/components/TodoEditorSheet/AlarmTimeSettingsSection.jsx
@@ -4,6 +4,7 @@ import DateTimePicker, {
   DateTimePickerAndroid,
 } from "@react-native-community/datetimepicker";
 import colors from "../../../../shared/styles/colors";
+import {toast} from "../../../../shared/components/toast/CenterToast";
 
 /**
  * Alarm UI (alarmBox ~ alarmFooter) 전담 컴포넌트
@@ -69,8 +70,17 @@ export default function AlarmTimeSettingSection({
   }, [setHasPickedAlarmTime, setAlarmTime, setIsIosInlineAlarmPickerOpen]);
 
   const handleApply = useCallback(() => {
+    // ✅ 현재 시간 가져오기
+    const now = new Date();
+
     // ✅ iOS picker가 열려있었다면 무조건 시간이 선택된 것으로 간주
     if (Platform.OS === "ios" && isIosInlineAlarmPickerOpen) {
+      // 선택한 시간이 현재 시간 이전인지 확인
+      if (alarmDraftDate <= now) {
+        toast.show("알림 시간은 현재 시간 이후로 설정해야 합니다.");
+        return;
+      }
+
       setAlarmTime(hhmm);
       setHasPickedAlarmTime(true);
       setIsIosInlineAlarmPickerOpen(false);
@@ -83,6 +93,12 @@ export default function AlarmTimeSettingSection({
       setAlarmTime(null);
       setIsIosInlineAlarmPickerOpen(false);
       onClosePanel?.();
+      return;
+    }
+
+    // ✅ Android에서 시간을 고른 상태면 그 값 적용 (시간 체크)
+    if (alarmDraftDate <= now) {
+      toast.show("알림 시간은 현재 시간 이후로 설정해야 합니다.");
       return;
     }
 
@@ -99,6 +115,7 @@ export default function AlarmTimeSettingSection({
     onClosePanel,
     hasPickedAlarmTime,
     isIosInlineAlarmPickerOpen,
+    alarmDraftDate,
   ]);
 
   return (

--- a/src/features/todo/components/TodoEditorSheet/AlarmTimeSettingsSection.jsx
+++ b/src/features/todo/components/TodoEditorSheet/AlarmTimeSettingsSection.jsx
@@ -69,6 +69,15 @@ export default function AlarmTimeSettingSection({
   }, [setHasPickedAlarmTime, setAlarmTime, setIsIosInlineAlarmPickerOpen]);
 
   const handleApply = useCallback(() => {
+    // ✅ iOS picker가 열려있었다면 무조건 시간이 선택된 것으로 간주
+    if (Platform.OS === "ios" && isIosInlineAlarmPickerOpen) {
+      setAlarmTime(hhmm);
+      setHasPickedAlarmTime(true);
+      setIsIosInlineAlarmPickerOpen(false);
+      onClosePanel?.();
+      return;
+    }
+
     // ✅ clear를 눌러서 "미설정" 상태면, 적용하기는 '삭제/미설정 적용'으로 동작
     if (!hasPickedAlarmTime) {
       setAlarmTime(null);
@@ -89,6 +98,7 @@ export default function AlarmTimeSettingSection({
     setIsIosInlineAlarmPickerOpen,
     onClosePanel,
     hasPickedAlarmTime,
+    isIosInlineAlarmPickerOpen,
   ]);
 
   return (

--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -988,10 +988,10 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
       onCloseAfterSubmit?.(); // ✅ 모달 없이 즉시 닫기
     } catch (e) {
       // ✅ 백엔드 에러 메시지 우선 표시
-      const message = e?.response?.data?.message;
-      if (message) {
-        toast.show(message);
-      }
+      // const message = e?.response?.data?.message;
+      // if (message) {
+      //   toast.show(message);
+      // }
       // 그 외에는 api.js의 인터셉터가 제네릭 토스트 처리
     }
   }, [

--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -863,6 +863,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
         }),
       );
     }
+    ("알림 시간은 현재 시간 이후로 설정해야 합니다.");
 
     // 2) 카테고리 변경
     if (

--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -8,7 +8,6 @@ import {
   ScrollView,
   TouchableOpacity,
   Keyboard,
-  Platform,
 } from "react-native";
 import {
   BottomSheetModal,
@@ -1131,12 +1130,12 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
       backgroundStyle={{backgroundColor: "#FAFAFA"}}
       handleIndicatorStyle={{backgroundColor: "#D0D0D0", width: "38.4%"}}
       enableContentPanningGesture={false} // ✅ content로는 시트 이동 X (고정)
-      bottomInset={Platform.OS === "ios" ? 0 : insets.bottom}
+      bottomInset={insets.bottom}
       enablePanDownToClose={false}
       // detached={true}
     >
       <BottomSheetView>
-        <View style={[styles.container, Platform.OS === "ios" && {paddingBottom: 15}]}>
+        <View style={styles.container}>
           {/* (선택) 로딩 표시 */}
           {mode === "edit" && (isTodoDetailLoading || isTodoDetailFetching) ? (
             <Text style={{fontSize: 12, color: "#B0B0B0", marginBottom: 8}}>

--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -291,7 +291,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
   },
   ref,
 ) {
-  // const insets = useSafeAreaInsets();
+  const insets = useSafeAreaInsets();
   const repeatPayload = useRepeatEditorStore.getState().getRepeatPayload();
 
   const EDIT_TOOL_ICONS = [
@@ -1135,7 +1135,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
       // detached={true}
     >
       <BottomSheetView>
-        <View style={styles.container}>
+        <View style={[styles.container, {paddingBottom: Math.min(insets.bottom, 15)}]}>
           {/* (선택) 로딩 표시 */}
           {mode === "edit" && (isTodoDetailLoading || isTodoDetailFetching) ? (
             <Text style={{fontSize: 12, color: "#B0B0B0", marginBottom: 8}}>
@@ -1532,7 +1532,7 @@ const styles = StyleSheet.create({
     // flex: 1,
     paddingHorizontal: 20,
     paddingTop: 8,
-    paddingBottom: 15,
+    // paddingBottom: 16,
   },
 
   categoryInlineRow: {

--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -291,7 +291,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
   },
   ref,
 ) {
-  const insets = useSafeAreaInsets();
+  // const insets = useSafeAreaInsets();
   const repeatPayload = useRepeatEditorStore.getState().getRepeatPayload();
 
   const EDIT_TOOL_ICONS = [
@@ -885,6 +885,11 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
     }
     // ✅ 알림 신규 설정/시간 변경
     else if (initialNotifyAt !== currentNotifyAt && currentNotifyAt) {
+      const alarmDate = new Date(currentNotifyAt);
+      if (alarmDate < new Date()) {
+        toast.show("알림 시간은 현재 시간 이후로 설정해야 합니다.");
+        return; // 여기서 중단
+      }
       tasks.push(setAlarm({todoId: numericTodoId, notifyAt: currentNotifyAt}));
     }
 
@@ -982,8 +987,12 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
       await Promise.all(tasks);
       onCloseAfterSubmit?.(); // ✅ 모달 없이 즉시 닫기
     } catch (e) {
-      // axios interceptor에서 토스트 처리 중이면 여기서는 조용히
-      // 필요하면 추가 toast 가능
+      // ✅ 백엔드 에러 메시지 우선 표시
+      const message = e?.response?.data?.message;
+      if (message) {
+        toast.show(message);
+      }
+      // 그 외에는 api.js의 인터셉터가 제네릭 토스트 처리
     }
   }, [
     mode,
@@ -1121,7 +1130,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
       backgroundStyle={{backgroundColor: "#FAFAFA"}}
       handleIndicatorStyle={{backgroundColor: "#D0D0D0", width: "38.4%"}}
       enableContentPanningGesture={false} // ✅ content로는 시트 이동 X (고정)
-      bottomInset={insets.bottom}
+      bottomInset={0}
       enablePanDownToClose={false}
       // detached={true}
     >
@@ -1294,10 +1303,16 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
                   <TodoBottomSheetTextInput
                     inputRef={memoInputRef}
                     value={memoText}
-                    onChangeText={setMemoText}
+                    onChangeText={(text) => {
+                      if (text.length > 100) {
+                        toast.show("메모는 100자까지 입력 가능합니다.");
+                        return;
+                      }
+                      setMemoText(text);
+                    }}
                     onEnabledChange={() => {}}
                     placeholder="기억해야 할 메모를 입력해 주세요."
-                    maxLength={200}
+                    maxLength={101}
                     multiline
                     blurOnSubmit={false}
                     scrollEnabled
@@ -1517,7 +1532,7 @@ const styles = StyleSheet.create({
     // flex: 1,
     paddingHorizontal: 20,
     paddingTop: 8,
-    // paddingBottom: 16,
+    paddingBottom: 15,
   },
 
   categoryInlineRow: {

--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -989,10 +989,10 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
       onCloseAfterSubmit?.(); // ✅ 모달 없이 즉시 닫기
     } catch (e) {
       // ✅ 백엔드 에러 메시지 우선 표시
-      // const message = e?.response?.data?.message;
-      // if (message) {
-      //   toast.show(message);
-      // }
+      const message = e?.response?.data?.message;
+      if (message) {
+        toast.show(message);
+      }
       // 그 외에는 api.js의 인터셉터가 제네릭 토스트 처리
     }
   }, [

--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   TouchableOpacity,
   Keyboard,
+  Platform,
 } from "react-native";
 import {
   BottomSheetModal,
@@ -1130,12 +1131,12 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
       backgroundStyle={{backgroundColor: "#FAFAFA"}}
       handleIndicatorStyle={{backgroundColor: "#D0D0D0", width: "38.4%"}}
       enableContentPanningGesture={false} // ✅ content로는 시트 이동 X (고정)
-      bottomInset={0}
+      bottomInset={Platform.OS === "ios" ? 0 : insets.bottom}
       enablePanDownToClose={false}
       // detached={true}
     >
       <BottomSheetView>
-        <View style={[styles.container, {paddingBottom: Math.min(insets.bottom, 15)}]}>
+        <View style={[styles.container, Platform.OS === "ios" && {paddingBottom: 15}]}>
           {/* (선택) 로딩 표시 */}
           {mode === "edit" && (isTodoDetailLoading || isTodoDetailFetching) ? (
             <Text style={{fontSize: 12, color: "#B0B0B0", marginBottom: 8}}>

--- a/src/features/todo/screens/Home/HomeScreen.jsx
+++ b/src/features/todo/screens/Home/HomeScreen.jsx
@@ -328,6 +328,7 @@ export default function HomeScreen({navigation, route}) {
         date: t.date,
         recurrenceId: t.recurrenceId,
         occurrenceDate: t.occurrenceDate,
+        memo: t.memo ?? "",
       }));
   }, [rawTodos]);
 
@@ -490,80 +491,78 @@ export default function HomeScreen({navigation, route}) {
           </TouchableOpacity>
         </View>
       </View>
-      {/* ✅ (고정) illustrationWrapper: 여기서는 스크롤 안 됨 */}
-      <GestureDetector gesture={panGesture}>
-        <View style={styles.illustrationWrapper}>
-          {!isCharacterError && <SpeechBubble text={bubbleText} />}
-          <Pressable
-            style={styles.lottieWrapper}
-            onPress={() => {
-              const status = characterStatus?.status;
-              const pool = BUBBLE_MENTS[status] ?? null;
-
-              setBubbleText((prev) =>
-                pickRandomDifferent(pool, prev, "대충 응원하는 문구"),
-              );
-            }}
-          >
-            {isCharacterBusy ? (
-              // <View style={styles.spinnerWrapper}>
-              //   <ActivityIndicator size="large" color={colors.gr500} />
-              // </View>
-              <></>
-            ) : isCharacterError ? (
-              // 2️⃣ ❌ 에러 → 로컬 에러 이미지
-              <Image
-                source={ErrorImage}
-                style={styles.errorImage}
-                resizeMode="contain"
-              />
-            ) : (
-              <>
-                {shouldRenderBack && (
-                  <LottieView
-                    source={
-                      lottieKey === "caseE1"
-                        ? TodoLottie.caseE1Back
-                        : TodoLottie.caseE2Back
-                    }
-                    autoPlay
-                    loop={false}
-                    style={styles.lottie}
-                  />
-                )}
-
-                {/* ✅ 메인 캐릭터 */}
-                <LottieView
-                  source={TodoLottie[lottieKey]}
-                  autoPlay
-                  loop={false}
-                  style={styles.lottie}
-                />
-              </>
-            )}
-          </Pressable>
-          {!isCharacterError && (
-            <View style={styles.shadowWrapper}>
-              {isShadowGR ? (
-                <ShadowGRIcon height="100%" width="100%" />
-              ) : (
-                <ShadowORIcon height="100%" width="100%" />
-              )}
-            </View>
-          )}
-        </View>
-      </GestureDetector>
-      {/* ✅ (고정) 구분선 */}
-      <View className="mx-1">
-        <Dotted style={{ width: "100%" }} height={1} />
-      </View>
-
-
       <View style={{flex: 1}}>
         <TodoBoardSection
           navigation={navigation}
           date={date}
           isViewingToday={isViewingToday}
+          ListHeaderComponent={
+            <>
+              {/* 캐릭터 영역: 스크롤과 함께 이동 */}
+              <GestureDetector gesture={panGesture}>
+                <View style={styles.illustrationWrapper}>
+                  {!isCharacterError && <SpeechBubble text={bubbleText} />}
+                  <Pressable
+                    style={styles.lottieWrapper}
+                    onPress={() => {
+                      const status = characterStatus?.status;
+                      const pool = BUBBLE_MENTS[status] ?? null;
+
+                      setBubbleText((prev) =>
+                        pickRandomDifferent(pool, prev, "대충 응원하는 문구"),
+                      );
+                    }}
+                  >
+                    {isCharacterBusy ? (
+                      <></>
+                    ) : isCharacterError ? (
+                      <Image
+                        source={ErrorImage}
+                        style={styles.errorImage}
+                        resizeMode="contain"
+                      />
+                    ) : (
+                      <>
+                        {shouldRenderBack && (
+                          <LottieView
+                            source={
+                              lottieKey === "caseE1"
+                                ? TodoLottie.caseE1Back
+                                : TodoLottie.caseE2Back
+                            }
+                            autoPlay
+                            loop={false}
+                            style={styles.lottie}
+                          />
+                        )}
+
+                        {/* 메인 캐릭터 */}
+                        <LottieView
+                          source={TodoLottie[lottieKey]}
+                          autoPlay
+                          loop={false}
+                          style={styles.lottie}
+                        />
+                      </>
+                    )}
+                  </Pressable>
+                  {!isCharacterError && (
+                    <View style={styles.shadowWrapper}>
+                      {isShadowGR ? (
+                        <ShadowGRIcon height="100%" width="100%" />
+                      ) : (
+                        <ShadowORIcon height="100%" width="100%" />
+                      )}
+                    </View>
+                  )}
+                </View>
+              </GestureDetector>
+              {/* 구분선 */}
+              <View className="mx-1">
+                <Dotted style={{ width: "100%" }} height={1} />
+              </View>
+            </>
+          }
         />
       </View>
     </SafeAreaView>
@@ -580,7 +579,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    height: "11%",
+    height: "10%",
   },
   todoScroll: {
     flex: 1, // ✅ 남은 영역을 TodoCard 스크롤이 차지


### PR DESCRIPTION
## Title
- 홈 스크롤 통합, 투두 메모 표시, 바텀시트 하단 여백 수정                                                                                                          
                                                                                                                                                                                                                                                                          

## Summary                                                                                                                                                       
  - 홈 화면 캐릭터 영역과 투두 카테고리 영역을 하나의 스크롤로 통합 (상단 날짜/아이콘 바는 고정)                                                                   
  - 투두 아이템 하단에 백엔드에서 전달받은 memo 텍스트 표시                                                                                                        
  - 바텀시트 bottomInset을 플랫폼별 동적 처리 (iOS/Android 호환)     