### PR TITLE
Fix: calendar 조회 로직 변경 및 오류 해결

### DIFF
--- a/src/features/calendar/screens/CalendarScreen.jsx
+++ b/src/features/calendar/screens/CalendarScreen.jsx
@@ -136,16 +136,10 @@ export default function CalendarScreen({ navigation }) {
       const monthEnd = currentDate.endOf("month");
       const today = dayjs();
 
-      let startDate = monthStart.format("YYYY-MM-DD");
-      let endDate = (monthEnd.isAfter(today, "day") ? today : monthEnd).format(
-        "YYYY-MM-DD",
-      );
-
-      if (dayjs(startDate).isAfter(dayjs(endDate), "day")) {
-        const tmp = startDate;
-        startDate = endDate;
-        endDate = tmp;
-      }
+      const startDate = monthStart.format("YYYY-MM-DD");
+      const endDate = monthEnd.isSame(today, "month")
+        ? today.format("YYYY-MM-DD")
+        : monthEnd.format("YYYY-MM-DD");
 
       let alive = true;
 

--- a/src/features/calendar/screens/CalendarScreen.jsx
+++ b/src/features/calendar/screens/CalendarScreen.jsx
@@ -137,7 +137,7 @@ export default function CalendarScreen({ navigation }) {
       const today = dayjs();
 
       const startDate = monthStart.format("YYYY-MM-DD");
-      const endDate = monthEnd.isSame(today, "month")
+      const endDate = currentDate.isSame(today, "month")
         ? today.format("YYYY-MM-DD")
         : monthEnd.format("YYYY-MM-DD");
 


### PR DESCRIPTION
## **📋 작업 개요**
- calendar 조회 오류 해결

## **📝 작업 상세 설명**
- endDate를 monthEnd 기준 비교에서 현재 월 여부 기준으로 변경
- 현재 월이면 today, 그 외는 monthEnd로 설정
- swap 로직 삭제