### PR TITLE
fix: 메모 기능 한글 깨짐 수정

### DIFF
--- a/src/features/todo/components/TodoEditorSheet/EditTodoSection.jsx
+++ b/src/features/todo/components/TodoEditorSheet/EditTodoSection.jsx
@@ -50,13 +50,7 @@ export default function EditTodoSection({
         visible={isMemoOpen}
         memoInputRef={memoInputRef}
         value={memoText}
-        onChangeText={(text) => {
-          if (text.length > 100) {
-            toast.show("메모는 100자까지 입력 가능합니다.");
-            return;
-          }
-          setMemoText(text);
-        }}
+        onChangeText={setMemoText}
         isFocused={isMemoFocused}
         setIsFocused={setIsMemoFocused}
       />

--- a/src/features/todo/components/TodoEditorSheet/components/MemoSection.jsx
+++ b/src/features/todo/components/TodoEditorSheet/components/MemoSection.jsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useRef } from "react";
 import { View } from "react-native";
 import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
+import { toast } from "../../../../../shared/components/toast/CenterToast";
+import colors from "../../../../../shared/styles/colors";
 
 export default function MemoSection({
   visible,
@@ -10,7 +12,22 @@ export default function MemoSection({
   isFocused,
   setIsFocused,
 }) {
+  const currentTextRef = useRef(value ?? "");
   if (!visible) return null;
+
+  const handleChangeText = (text) => {
+    currentTextRef.current = text;
+    onChangeText(text);
+  };
+
+  const handleKeyPress = ({ nativeEvent }) => {
+    if (
+      currentTextRef.current.length >= 100 &&
+      nativeEvent.key !== "Backspace"
+    ) {
+      toast.show("메모는 100자까지 입력 가능합니다.");
+    }
+  };
 
   return (
     <View
@@ -18,23 +35,28 @@ export default function MemoSection({
       style={isFocused ? { borderColor: "#EAEAEA" } : null}
     >
       <BottomSheetTextInput
+
         ref={memoInputRef}
-        value={value ?? ""}
-        onChangeText={onChangeText}
+        defaultValue={value ?? ""}
+        onChangeText={handleChangeText}
+        onKeyPress={handleKeyPress}
+        maxLength={100}
         placeholder="기억해야 할 메모를 입력해 주세요."
         placeholderTextColor="#C6C6C6"
-        maxLength={101}
         multiline
         blurOnSubmit={false}
         scrollEnabled
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
-        className="py-0 text-[12px] text-gr700"
         style={{
           fontFamily: "Pretendard-Medium",
+          fontSize: 12,
           lineHeight: 18,
           maxHeight: 54,
           textAlignVertical: "top",
+          paddingTop: 0,
+          paddingBottom: 0,
+          color:colors.gr700
         }}
       />
     </View>


### PR DESCRIPTION
## 📌 Related Issue
close #87 
- 메모 입력창에서 한글 입력 시 자모가 분리되거나 글자가 깨지는 현상

## 🚀 Description
- 기존 `controlled input` 방식에서 한글 조합 중 `value`가 계속 갱신되며 IME 조합이 끊기는 문제가 있었음
- `BottomSheetTextInput`을 `defaultValue` 기반의 uncontrolled input 방식으로 변경해 한글 조합 상태가 유지되도록 수정
- 글자 수 제한은 `maxLength`와 `onKeyPress` 기준으로 처리하도록 변경