### PR TITLE
[FIX] YearMonthWeel 스크롤 감도 및 UX 개선

### DIFF
--- a/src/features/todo/components/RepeatSettingsSection/wheel/WheelColumn.jsx
+++ b/src/features/todo/components/RepeatSettingsSection/wheel/WheelColumn.jsx
@@ -31,19 +31,23 @@ export default function WheelColumn({
   const onMomentumEnd = useCallback(
     (e) => {
       const y = e.nativeEvent.contentOffset.y;
-      const idx = Math.round(y / itemHeight);
 
-        if (isDisabled?.(idx)) {
-            ref.current?.scrollToOffset({
-                offset: selectedIndex * itemHeight,
-                animated: true,
-            });
-            return;
-        }
+      const idx = Math.max(
+        0,
+        Math.min(data.length - 1, Math.round(y / itemHeight))
+      );
+
+      if (isDisabled?.(idx)) {
+        ref.current?.scrollToOffset({
+          offset: selectedIndex * itemHeight,
+          animated: true,
+        });
+        return;
+      }
 
       onChangeIndex?.(idx);
     },
-    [itemHeight, onChangeIndex, isDisabled, selectedIndex]
+    [data.length, itemHeight, onChangeIndex, isDisabled, selectedIndex]
   );
 
   const handleSelect = (index) => {
@@ -69,6 +73,7 @@ export default function WheelColumn({
         bounces={false}
         contentContainerStyle={{paddingVertical: padding}}
         onMomentumScrollEnd={onMomentumEnd}
+        onScrollEndDrag={onMomentumEnd}
         getItemLayout={(_, index) => ({
           length: itemHeight,
           offset: itemHeight * index,

--- a/src/features/todo/components/RepeatSettingsSection/wheel/YearMonthWheelModal.jsx
+++ b/src/features/todo/components/RepeatSettingsSection/wheel/YearMonthWheelModal.jsx
@@ -131,8 +131,16 @@ export default function YearMonthWheelModal({
                 data={years}
                 selectedIndex={yearIdx}
                 onChangeIndex={(idx) => {
+                  const nextYear = years[idx];
+                  const nextMonths = available
+                    ? available.monthsByYear.get(nextYear) ?? []
+                    : range(1, 12);
+
+                  const currentMonth = months[monthIdx];
+                  const nextMonthIdx = nextMonths.indexOf(currentMonth);
+
                   setYearIdx(idx);
-                  setMonthIdx(0);
+                  setMonthIdx(nextMonthIdx >= 0 ? nextMonthIdx : 0);
                 }}
                 renderLabel={(y) => `${y}년`}
                 containerStyle={styles.wheelColBox}


### PR DESCRIPTION
## 📌 Related Issue
close #92 

## 🚀 Description
- `onMomentumScrollEnd`만 사용하던 구조에서 `onScrollEndDrag`를 추가하여 짧은 드래그에도 선택값이 즉시 반영되도록 개선
- Wheel picker 스크롤 선택 반응성 및 UX 개선
- 연도 변경 시 monthIdx를 0으로 초기화하던 로직 수정