### PR TITLE
[FIX] bottomSheet keyboard 이슈 해결

### DIFF
--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -659,7 +659,6 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
     setHasAppliedTodoDate(false);
     setIsSheetReady(false);
     resetEditHydrationRefs();
-    Keyboard.dismiss();
     onDismiss?.();
     isSubmittingRef.current = false;
   }, [
@@ -782,10 +781,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
         recurrence,
       });
 
-      Keyboard.dismiss();
-      requestAnimationFrame(() => {
-        ref?.current?.dismiss?.();
-      });
+      onCloseAfterSubmit?.();
 
       return;
     }
@@ -935,7 +931,6 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
       for (const task of tasks) {
         await task();
       }
-
       onEditSuccess?.(draftCategoryId);
       onCloseAfterSubmit?.();
     } catch (e) {
@@ -963,20 +958,20 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
     onSubmit,
     onEditSuccess,
     onCloseAfterSubmit,
-    ref,
   ]);
 
   const handleSheetAnimate = useCallback(
     (fromIndex, toIndex) => {
       if (fromIndex === -1 && toIndex >= 0) {
-        if (!isReturningFromBackgroundRef.current) {
-          focusTitleInput();
-        }
+        sheetReadyTimerRef.current = setTimeout(() => {
+          setIsSheetReady(true);
 
-        sheetReadyTimerRef.current = setTimeout(
-          () => setIsSheetReady(true),
-          Platform.OS === "ios" ? 1150 : 0,
-        );
+          if (!isReturningFromBackgroundRef.current) {
+            requestAnimationFrame(() => {
+              focusTitleInput();
+            });
+          }
+        }, Platform.OS === "ios" ? 300 : 100);
       }
 
       if (toIndex === -1) {
@@ -1002,7 +997,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
       ref={ref}
       index={0}
       enableDynamicSizing
-      maxDynamicContentSize={550}
+      maxDynamicContentSize={650}
       backdropComponent={renderBackdrop}
       onDismiss={handleDismiss}
       onAnimate={handleSheetAnimate}

--- a/src/features/todo/hooks/useTodoEditorController.js
+++ b/src/features/todo/hooks/useTodoEditorController.js
@@ -35,11 +35,17 @@ export function useTodoEditorController({
 
   const closeEditorTogether = useCallback(() => {
     isClosingRef.current = true;
+    bottomSheetRef.current?.dismiss?.();
+  }, []);
+
+  const closeEditorAfterSubmit = useCallback(() => {
+    isClosingRef.current = true;
     Keyboard.dismiss();
     bottomSheetRef.current?.dismiss?.();
   }, []);
 
   const requestCloseEditorTogether = useCallback(() => {
+    Keyboard.dismiss();
     open({
       title: "투두 설정 그만두기",
       description:
@@ -181,7 +187,7 @@ export function useTodoEditorController({
       mode: sheetMode,
       initialValue: editingTodo?.title ?? "",
       onCloseTogether: requestCloseEditorTogether,
-      onCloseAfterSubmit: closeEditorTogether,
+      onCloseAfterSubmit: closeEditorAfterSubmit,
       onDismiss,
       categoryLabel: sheetCategory?.label ?? "카테고리",
       categories,
@@ -192,6 +198,7 @@ export function useTodoEditorController({
       categories,
       requestCloseEditorTogether,
       closeEditorTogether,
+      closeEditorAfterSubmit,
       editingTodo,
       handleSubmit,
       onDismiss,


### PR DESCRIPTION
## 📌 Related Issue
close #94 

## 🚀 Description
* BottomSheet 닫힘 시 키보드와의 충돌로 인해 발생하던 애니메이션 이슈 수정
* `backdrop` 클릭 후 확인 모달 진입 시 키보드를 먼저 dismiss 하도록 수정
* 제출 완료 후 닫힘 동작과 일반 닫힘 동작을 분리하여 처리
* `submit` 이후에는 `closeEditorAfterSubmit` 경로를 통해 `keyboard dismiss` 후 `sheet dismiss` 되도록 수정
* 일반 닫기(`confirm modal → dismiss`)는 기존 `dismiss` 흐름 유지
* `keyboardBlurBehavior="restore"` 환경에서 발생하던 키보드 재등장 및 잔류 현상 개선
* BottomSheet 내부 컨텐츠 증가 시 일부 영역이 잘리던 문제 수정 (`maxDynamicContentSize` 650으로 조정)
* 간헐적으로 키보드가 BottomSheet 상단에 붙어 보이던 레이아웃 이슈 개선