### PR TITLE
feat: 반복 투두 해제 시 scope 기반 정책 처리 추가

### DIFF
--- a/src/features/todo/components/RepeatSettingsSection/RepeatSettingsSection.jsx
+++ b/src/features/todo/components/RepeatSettingsSection/RepeatSettingsSection.jsx
@@ -382,7 +382,13 @@ export default function RepeatSettingsSection({
   const shouldShowRepeatReset =
     isRepeatCycleSet || isRepeatStartSet || isRepeatEndSet || isRepeatAlarmSet;
 
+  const setIsCancelRecurrence = useRepeatEditorStore(
+    (s) => s.setIsCancelRecurrence,
+  );
+
   const handleResetRepeatAll = useCallback(() => {
+    setIsCancelRecurrence(true);
+
     setRepeatCycle("unset");
     setRepeatWeekdays([]);
     setRepeatMonthDays([]);
@@ -398,6 +404,7 @@ export default function RepeatSettingsSection({
 
     if (openKey !== null) onToggleOpenKey(openKey);
   }, [
+    setIsCancelRecurrence,
     setRepeatCycle,
     setRepeatWeekdays,
     setRepeatMonthDays,

--- a/src/features/todo/components/TodoBoardSection.jsx
+++ b/src/features/todo/components/TodoBoardSection.jsx
@@ -38,7 +38,7 @@ import { useCreateTodoRecurrenceMutation } from "../queries/sheet/repeat/useCrea
 import { useUpdateTodoDateMutation } from "../queries/sheet/date/useUpdateTodoDateMutation";
 import { useDeleteTodoInstanceMutation } from "../queries/sheet/repeat/useDeleteTodoInstanceMutation";
 import { useUpdateTodoInstanceMutation } from "../queries/sheet/repeat/useUpdateTodoInstanceMutation";
-
+import { useCancelTodoInstanceMutation } from "../queries/sheet/repeat/useCancelTodoInstanceMutation";
 
 function Chevron({ isOpen, color }) {
   return (
@@ -273,6 +273,9 @@ export default function TodoBoardSection({
   const { mutateAsync: updateTodoInstanceMutateAsync } =
     useUpdateTodoInstanceMutation();
 
+  const { mutateAsync: cancelTodoInstanceMutateAsync } =
+    useCancelTodoInstanceMutation();
+
   const isRecurringTodo = (todo) => {
     const rid = todo?.recurrenceId;
     return rid !== null && rid !== undefined && Number(rid) !== 0;
@@ -285,20 +288,25 @@ export default function TodoBoardSection({
   };
 
   const openRecurringEditModal = useCallback(
-    ({ todo, payload, onDone }) => {
+    ({ todo, payload, onDone, isCancelRecurrence = false }) => {
       const instanceId = Number(todo?.id);
       if (!instanceId) return;
 
       const handleUpdate = async (scope) => {
-        const body = {
-          scope,
-          payload,
-        };
-
-        await updateTodoInstanceMutateAsync({
-          instanceId,
-          body,
-        });
+        if (isCancelRecurrence) {
+          await cancelTodoInstanceMutateAsync({
+            instanceId,
+            body: { scope },
+          });
+        } else {
+          await updateTodoInstanceMutateAsync({
+            instanceId,
+            body: {
+              scope,
+              payload,
+            },
+          });
+        }
 
         onDone?.();
         close();
@@ -327,7 +335,7 @@ export default function TodoBoardSection({
         ],
       });
     },
-    [open, close, updateTodoInstanceMutateAsync],
+    [open, close, updateTodoInstanceMutateAsync, cancelTodoInstanceMutateAsync],
   );
 
   const editor = useTodoEditorController({
@@ -345,6 +353,7 @@ export default function TodoBoardSection({
                            notifyAt,
                            recurrence,
                            onDone,
+                           isCancelRecurrence,
                          }) => {
       if (!todo?.id) {
         const created = await createTodoMutateAsync({
@@ -426,6 +435,7 @@ export default function TodoBoardSection({
           todo,
           payload,
           onDone,
+          isCancelRecurrence,
         });
         return;
       }

--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -377,8 +377,11 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
       repeatMonthDays: s.repeatMonthDays,
       repeatYearMonths: s.repeatYearMonths,
       repeatYearDays: s.repeatYearDays,
+      isCancelRecurrence: s.isCancelRecurrence,
     })),
   );
+
+  const isCancelRecurrence = repeatSnapshot.isCancelRecurrence;
 
   const {
     inputRef,
@@ -757,31 +760,37 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
 
       isSubmittingRef.current = true;
 
-      const dateStr = toYYYYMMDD(todoDate);
+      try {
+        const dateStr = toYYYYMMDD(todoDate);
 
-      const notifyAt = hasPickedAlarmTime
-        ? buildNotifyAt({
-          dateStr,
-          timeStr: alarmTime,
-        })
-        : null;
+        const notifyAt = hasPickedAlarmTime
+          ? buildNotifyAt({
+            dateStr,
+            timeStr: alarmTime,
+          })
+          : null;
 
-      const repeatDraft = useRepeatEditorStore.getState().getRepeatPayload?.();
+        const repeatDraft = useRepeatEditorStore.getState().getRepeatPayload?.();
 
-      const recurrence = buildCreateRecurrencePayload(repeatDraft, {
-        alarmTimeHHmm: hasPickedAlarmTime ? alarmTime : null,
-      });
+        const recurrence = buildCreateRecurrencePayload(repeatDraft, {
+          alarmTimeHHmm: hasPickedAlarmTime ? alarmTime : null,
+        });
 
-      await onSubmit?.({
-        categoryId: draftCategoryId,
-        description: text,
-        date: dateStr,
-        memo: normalizeMemo(memoText),
-        notifyAt,
-        recurrence,
-      });
+        await onSubmit?.({
+          categoryId: draftCategoryId,
+          description: text,
+          date: dateStr,
+          memo: normalizeMemo(memoText),
+          notifyAt,
+          recurrence,
+        });
 
-      onCloseAfterSubmit?.();
+        onCloseAfterSubmit?.();
+      } catch (e) {
+        console.log("create todo error", e);
+      } finally {
+        isSubmittingRef.current = false;
+      }
 
       return;
     }
@@ -830,7 +839,8 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
         todo: {
           ...todoDetail,
           id: numericTodoId,
-          recurrenceId: todoDetail?.recurrence?.recurrenceId ?? todoDetail?.recurrenceId ?? true,
+          recurrenceId:
+            todoDetail?.recurrence?.recurrenceId ?? todoDetail?.recurrenceId ?? true,
         },
         text: currentDescription,
         description: currentDescription,
@@ -840,6 +850,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
         memo: currentMemo,
         notifyAt: currentNotifyAt,
         recurrence: isRepeatCleared ? null : repeatPayload,
+        isCancelRecurrence,
       });
 
       isSubmittingRef.current = false;
@@ -958,6 +969,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
     onSubmit,
     onEditSuccess,
     onCloseAfterSubmit,
+    isCancelRecurrence,
   ]);
 
   const handleSheetAnimate = useCallback(

--- a/src/features/todo/hooks/useTodoEditorController.js
+++ b/src/features/todo/hooks/useTodoEditorController.js
@@ -166,6 +166,9 @@ export function useTodoEditorController({
           memo: isPayload ? payloadOrCategoryId.memo : undefined,
           notifyAt: isPayload ? payloadOrCategoryId.notifyAt : undefined,
           recurrence: isPayload ? payloadOrCategoryId.recurrence : undefined,
+          isCancelRecurrence: isPayload
+            ? payloadOrCategoryId.isCancelRecurrence
+            : false,
         });
       }
 

--- a/src/features/todo/queries/sheet/repeat/useCancelTodoInstanceMutation.js
+++ b/src/features/todo/queries/sheet/repeat/useCancelTodoInstanceMutation.js
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { sheetApi } from "../sheetApi";
+import { sheetKeys } from "../sheetKeys";
+import { homeKeys } from "../../home/homeKeys";
+
+export function useCancelTodoInstanceMutation(options = {}) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: sheetApi.cancelTodoInstance,
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: sheetKeys.all });
+      queryClient.invalidateQueries({ queryKey: homeKeys.all });
+
+      queryClient.removeQueries({
+        queryKey: sheetKeys.todoDetail(variables.instanceId),
+      });
+
+      options?.onSuccess?.(data, variables, context);
+    },
+
+    ...options,
+  });
+}

--- a/src/features/todo/queries/sheet/sheetApi.js
+++ b/src/features/todo/queries/sheet/sheetApi.js
@@ -1,12 +1,10 @@
 // src/features/todo/queries/sheet/sheetApi.js
 import api from "../../../../shared/lib/api";
-// ✅ 위 경로는 예시야. 실제 api.js 위치에 맞게 조정해줘.
 
 export const sheetApi = {
   // 투두 생성: POST /api/todos
   createTodo: async ({description, categoryId, date}) => {
     const body = {description, categoryId};
-    // date는 optional (없으면 서버가 "오늘"로 생성) :contentReference[oaicite:1]{index=1}
     if (date) body.date = date; // "YYYY-MM-DD"
     const res = await api.post("/api/todos", body);
     return res.data;
@@ -123,6 +121,10 @@ export const sheetApi = {
     return res.data;
   },
 
+  cancelTodoInstance: async ({instanceId, body}) => {
+    const res = await api.patch(`/api/todos/instances/${instanceId}/cancel-recurrence`, body);
+    return res.data;
+  },
 
   updateTodoInstance : async ({instanceId, body}) => {
     const res = await api.patch(`/api/todos/instances/${instanceId}`, body);

--- a/src/features/todo/stores/repeatEditorStore.js
+++ b/src/features/todo/stores/repeatEditorStore.js
@@ -1,18 +1,19 @@
 import {create} from "zustand";
 
 const initialState = {
-  repeatStartDate: null, // ✅ 미설정
-  repeatEndType: "unset", // ✅ "unset" | "none" | "date"
-  repeatEndDate: null, // ✅ 미설정
-  repeatCycle: "unset", // "unset" | "daily" | "weekly" | "monthly" | "yearly"
-  repeatAlarm: "unset", // "unset" | "sameTime" | "morning9" | "custom"
-  repeatAlarmTime: null, // ✅ "HH:mm" (예: "07:30") / custom일 때만 사용
+  repeatStartDate: null,
+  repeatEndType: "unset",
+  repeatEndDate: null,
+  repeatCycle: "unset",
+  repeatAlarm: "unset",
+  repeatAlarmTime: null,
 
-  // ✅ 반복 주기별 상세 선택값
-  repeatWeekdays: [], // ["mon","tue"...]
-  repeatMonthDays: [], // [1, 12, 28...]
-  repeatYearMonths: [], // [1..12]
-  repeatYearDays: [], // [1..31]
+  repeatWeekdays: [],
+  repeatMonthDays: [],
+  repeatYearMonths: [],
+  repeatYearDays: [],
+
+  isCancelRecurrence: false,
 };
 
 export const useRepeatEditorStore = create((set, get) => ({
@@ -29,6 +30,7 @@ export const useRepeatEditorStore = create((set, get) => ({
   setRepeatMonthDays: (days) => set({repeatMonthDays: days}),
   setRepeatYearMonths: (months) => set({repeatYearMonths: months}),
   setRepeatYearDays: (days) => set({repeatYearDays: days}),
+  setIsCancelRecurrence: (value) => set({ isCancelRecurrence: value }),
 
   // ✅ 한 번에 세팅 (예: 기존 todo 편집 진입 시)
   setRepeatAll: (partial) => set((s) => ({...s, ...partial})),


### PR DESCRIPTION
## 📌 Related Issue
close #96 

## 🚀 Description
* 반복 투두 해제 API 연동
* 반복 투두 수정 scope 모달 재사용하여 반복 해제 정책 연결
* `THIS, THIS_AND_FUTURE, ALL` scope 분기 처리 추가
* 반복 해제 상태(`isCancelRecurrence`) store 및 submit 흐름 연동
* 반복 해제 시 `cancel-recurrence` API 호출하도록 수정
* 반복 해제 후 홈/상세 `query invalidate` 처리 추가