### PR TITLE
[Fix] Todo 날짜 저장 및 닉네임 입력 필터링 오류 수정

### DIFF
--- a/src/features/auth/screens/Naming/NamingScreen.jsx
+++ b/src/features/auth/screens/Naming/NamingScreen.jsx
@@ -42,8 +42,10 @@ export default function NamingScreen({navigation, route}) {
 
   const onChangeNickname = (text) => {
     const raw = text ?? "";
-    const filtered = raw.replace(/[^가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9\sㆍ]/g,
-      "");
+    const filtered = raw.replace(
+      /[^가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9\sㆍᆢ]/g,
+      ""
+    );
     const limited = filtered.slice(0, NICKNAME_MAX);
     setDraft(limited);
     if (nicknameError) setNicknameError(null);

--- a/src/features/mypage/screens/EditProfile/EditProfile.jsx
+++ b/src/features/mypage/screens/EditProfile/EditProfile.jsx
@@ -109,7 +109,7 @@ export default function EditProfile({ navigation }) {
 
         // 한글 완성형 + 자모 + 영문 + 숫자 + 공백 허용
       const filtered = raw.replace(
-        /[^가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9\sㆍ]/g,
+        /[^가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9\sㆍᆢ]/g,
         ""
       );
 

--- a/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
+++ b/src/features/todo/components/TodoEditorSheet/TodoEditorSheet.jsx
@@ -340,6 +340,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
     categories = [],
     initialCategoryId = 0,
     todoId = null,
+    selectedDate,
   },
   ref,
 ) {
@@ -446,6 +447,7 @@ const TodoEditorSheet = React.forwardRef(function TodoEditorSheet(
   } = useTodoEditorDate({
     isSelectDateOpen,
     closePanelAndFocusTitle,
+    selectedDate,
   });
 
   const numericTodoId = useMemo(() => {

--- a/src/features/todo/components/TodoEditorSheet/hooks/useTodoEditorDate.js
+++ b/src/features/todo/components/TodoEditorSheet/hooks/useTodoEditorDate.js
@@ -43,14 +43,20 @@ const buildMonthGrid = (monthDate) => {
 
 export default function useTodoEditorDate({
   isSelectDateOpen,
-  closePanelAndFocusTitle,
+  closePanelAndFocusTitle, selectedDate,
 }) {
-  const [todoDate, setTodoDate] = useState(new Date());
-  const [draftTodoDate, setDraftTodoDate] = useState(new Date());
+  const getInitialDate = () => {
+    if (!selectedDate) return new Date();
+    const [y, m, d] = String(selectedDate).split("-").map(Number);
+    return new Date(y, m - 1, d);
+  };
+
+  const [todoDate, setTodoDate] = useState(getInitialDate);
+  const [draftTodoDate, setDraftTodoDate] = useState(getInitialDate);
   const [hasAppliedTodoDate, setHasAppliedTodoDate] = useState(false);
 
   const [todoMonthCursor, setTodoMonthCursor] = useState(() => {
-    const base = new Date();
+    const base = getInitialDate();
     return new Date(base.getFullYear(), base.getMonth(), 1);
   });
 
@@ -69,6 +75,19 @@ export default function useTodoEditorDate({
   );
 
   const today = useMemo(() => new Date(), []);
+
+  useEffect(() => {
+    if (!selectedDate) return;
+
+    const next = getInitialDate();
+
+    setTodoDate(next);
+    setDraftTodoDate(next);
+    setTodoMonthCursor(new Date(next.getFullYear(), next.getMonth(), 1));
+    setTodoWheelInitialYear(next.getFullYear());
+    setTodoWheelInitialMonth(next.getMonth() + 1);
+    setHasAppliedTodoDate(false);
+  }, [selectedDate]);
 
   useEffect(() => {
     if (!isSelectDateOpen) return;

--- a/src/features/todo/hooks/useTodoEditorController.js
+++ b/src/features/todo/hooks/useTodoEditorController.js
@@ -188,6 +188,7 @@ export function useTodoEditorController({
     () => ({
       ref: bottomSheetRef,
       mode: sheetMode,
+      selectedDate,
       initialValue: editingTodo?.title ?? "",
       onCloseTogether: requestCloseEditorTogether,
       onCloseAfterSubmit: closeEditorAfterSubmit,

--- a/src/features/todo/screens/Category/CategEditScreen.jsx
+++ b/src/features/todo/screens/Category/CategEditScreen.jsx
@@ -4,6 +4,7 @@ import {
   StyleSheet,
   TextInput,
   TouchableOpacity,
+  Keyboard,
   KeyboardAvoidingView,
   Platform,
   ActivityIndicator,
@@ -189,7 +190,7 @@ export default function CategEditScreen({ navigation, route }) {
     <SafeAreaView style={styles.safe} edges={["top", "bottom"]}>
       <KeyboardAvoidingView
         style={styles.flex}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        // behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
         <View className="px-5">
           <CategoryHeader
@@ -277,6 +278,7 @@ export default function CategEditScreen({ navigation, route }) {
                     key={c}
                     activeOpacity={0.8}
                     onPress={() => {
+                      Keyboard.dismiss();
                       setSelectedColor(c);
                     }}
                     className="mb-12 w-[30%] items-center"


### PR DESCRIPTION
## 📌 Related Issue
close #99 

## 🚀 Description
* 투두 생성 시 선택한 날짜 대신 오늘 날짜로 저장되던 문제 수정
* 천지인 키보드 입력 시 `ㆍ`, `ᆢ` 조합 문자가 정상 입력되지 않던 문제 수정
* 카테고리 편집 화면 UX 조정

## 원인
### 투두 날짜 저장 이슈
* `TodoEditorSheet` 내부에서 생성 시 `todoDate` 상태값을 기준으로 날짜를 저장하도록 변경된 상태였음
* 하지만 `useTodoEditorDate`의 초기값이 `new Date()`로 설정되어 있어, 선택한 날짜(`selectedDate`)가 아닌 현재 날짜가 기본값으로 적용되고 있었음
* 생성 시 전달받은 `selectedDate`를 기준으로 초기 날짜 상태를 설정하도록 수정

### 천지인 입력 이슈
* 천지인 키보드에서 `ㆍㆍ` 입력 시 두 번째 입력이 단순 반복 문자가 아니라 `ᆢ(U+11A2)` 조합 문자로 처리되고 있었음
* 기존 정규식 필터에서 해당 문자를 허용하지 않아 입력이 제거되던 문제 발생
* `ㆍ`, `ᆢ` 문자를 모두 허용하도록 입력 필터 수정

## 📢 Notes
* Android / iOS 크로스 체크 완료