### PR TITLE
[FIX] Input 최대 글자 입력 시 한글 깨짐 현상 해결

### DIFF
--- a/src/features/todo/components/TodoEditorSheet/components/MemoSection.jsx
+++ b/src/features/todo/components/TodoEditorSheet/components/MemoSection.jsx
@@ -16,17 +16,13 @@ export default function MemoSection({
   if (!visible) return null;
 
   const handleChangeText = (text) => {
-    currentTextRef.current = text;
-    onChangeText(text);
-  };
-
-  const handleKeyPress = ({ nativeEvent }) => {
-    if (
-      currentTextRef.current.length >= 100 &&
-      nativeEvent.key !== "Backspace"
-    ) {
+    const chars = [...text];
+    if (chars.length > 100) {
       toast.show("메모는 100자까지 입력 가능합니다.");
     }
+    const sliced = chars.slice(0, 100).join("");
+    currentTextRef.current = sliced;
+    onChangeText(sliced);
   };
 
   return (
@@ -37,10 +33,9 @@ export default function MemoSection({
       <BottomSheetTextInput
 
         ref={memoInputRef}
-        defaultValue={value ?? ""}
+        value={value}
         onChangeText={handleChangeText}
-        onKeyPress={handleKeyPress}
-        maxLength={100}
+        maxLength={101}
         placeholder="기억해야 할 메모를 입력해 주세요."
         placeholderTextColor="#C6C6C6"
         multiline

--- a/src/features/todo/components/TodoEditorSheet/components/MemoSection.jsx
+++ b/src/features/todo/components/TodoEditorSheet/components/MemoSection.jsx
@@ -27,9 +27,7 @@ export default function MemoSection({
 
   return (
     <View
-      className="rounded-2xl rounded-t-none bg-[#FAFAFA] px-4 py-3 border border-[#F2F2F2]"
-      style={isFocused ? { borderColor: "#EAEAEA" } : null}
-    >
+      className="rounded-2xl rounded-t-none bg-[#FAFAFA] px-4 py-3 border border-gr100 border-t-0">
       <BottomSheetTextInput
 
         ref={memoInputRef}

--- a/src/features/todo/components/TodoEditorSheet/components/TitleInputSection.jsx
+++ b/src/features/todo/components/TodoEditorSheet/components/TitleInputSection.jsx
@@ -27,10 +27,10 @@ function InputBase({
       onSubmitEditing={onSubmitEditing}
       placeholder={placeholder}
       placeholderTextColor="#C6C6C6"
-      maxLength={maxLength}
+      maxLength={maxLength+1}
       onKeyPress={({ nativeEvent }) => {
         if (
-          value?.length >= maxLength &&
+          value?.length > maxLength &&
           nativeEvent.key !== "Backspace"
         ) {
           onLimitPress?.();
@@ -72,6 +72,7 @@ export default function TitleInputSection({
   isMemoOpen = false,
   onFocusExtra,
   editable = true,
+  maxLength = 40,
 }) {
   const [localValue, setLocalValue] = React.useState(value ?? "");
 
@@ -81,10 +82,19 @@ export default function TitleInputSection({
 
   const handleChangeText = React.useCallback(
     (text) => {
-      setLocalValue(text);
-      onChangeText?.(text);
+      const chars = [...text];
+
+      if (chars.length > maxLength) {
+        toast.show("투두는 40자까지 입력 가능해요", {
+          position: "center",
+        });
+      }
+      const sliced = [...text].slice(0, maxLength).join("");
+
+      setLocalValue(sliced);
+      onChangeText?.(sliced);
     },
-    [onChangeText],
+    [maxLength, onChangeText],
   );
 
   const handleClear = React.useCallback(() => {

--- a/src/features/todo/screens/Category/CategEditScreen.jsx
+++ b/src/features/todo/screens/Category/CategEditScreen.jsx
@@ -104,7 +104,11 @@ export default function CategEditScreen({ navigation, route }) {
     (name?.trim?.() ?? "").length > 0 && selectedColor != null;
 
   const onChangeName = (text) => {
-    setName(text.slice(0, MAX_NAME_LEN));
+    const sliced = [...text].slice(0, 12).join("");
+
+    if (sliced !== name) {
+      setName(sliced);
+    }
   };
 
   const onPressSave = () => {
@@ -212,7 +216,7 @@ export default function CategEditScreen({ navigation, route }) {
               placeholderTextColor={colors?.gr300 ?? "#BDBDBD"}
               style={styles.input}
               returnKeyType="done"
-              maxLength={MAX_NAME_LEN}
+              maxLength={MAX_NAME_LEN+1}
               onFocus={() => setIsInputFocused(true)}
               onBlur={() => setIsInputFocused(false)}
             />


### PR DESCRIPTION
## 📌 Related Issue
close #101

## 🚀 Description
- iOS 환경에서 RN `TextInput` 사용 시 한글 마지막 받침 입력이 끊기는 문제 수정
- Category / Todo / Memo Input 동일 방식 적용
- Memo border style 오류 수정

## 🔍 Cause
- iOS 한글 IME 조합 과정과 RN controlled input 재렌더링 충돌로 인해 발생
- `maxLength` 직접 사용 시 마지막 한글 받침 입력이 정상 처리되지 않음

## ✅ Solution
- `maxLength + 1`로 조합 입력 여유 공간 확보
- 실제 state 값은 `slice`로 제한
- 초과 입력 시 toast 노출 방식으로 변경

## 📢 Notes
- 현재 방식은 한글 받침 입력 문제 해결을 우선 적용
- 최대 글자 수 초과 입력 시 순간적인 깜빡임 현상은 남아있어 추후 개선 예정